### PR TITLE
Skip routing rules when configuring ksocklnd

### DIFF
--- a/pkg/azurelustreplugin/entrypoint.sh
+++ b/pkg/azurelustreplugin/entrypoint.sh
@@ -136,6 +136,7 @@ if [[ "${installClientPackages}" == "yes" ]]; then
   if [[ "${init_lnet}" == "true" ]]; then
     echo "$(date -u) Loading the LNet."
     modprobe -v lnet
+    modprobe -v ksocklnd skip_mr_route_setup=1
     lnetctl lnet configure
 
     add_net_interfaces


### PR DESCRIPTION
This commit explicitly loads the ksocklnd module and configures the skip_mr_route_setup setting. This setup is not required for correct Lnet behavior, and breaks the network routing on AKS clusters with CNI networking. With this change, this now deploys, mounts, and connects correctly in both kubenet and cni configurations.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This commit explicitly loads the ksocklnd module and configures the skip_mr_route_setup setting. This setup is not required for correct Lnet behavior, and breaks the network routing on AKS clusters with CNI networking. With this change, this now deploys, mounts, and connects correctly in both kubenet and cni configurations.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #132 

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
