### PR TITLE
Changes to entrypoint for better resilience

### DIFF
--- a/pkg/azurelustreplugin/entrypoint.sh
+++ b/pkg/azurelustreplugin/entrypoint.sh
@@ -103,7 +103,7 @@ if [[ "${installClientPackages}" == "yes" ]]; then
 
   echo "$(date -u) Installing Lustre client packages for OS=${osReleaseCodeName}, kernel=${kernelVersion} "
 
-  if [ ! -f /etc/apt/sources.list.d/amlfs.list ]; then
+  if [ ! -f /etc/apt/sources.list.d/amlfs.list ] ||  ! ls /var/lib/apt/lists  | grep "packages.microsoft.com_repos_amlfs" &> /dev/null; then
     curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
     echo "deb [arch=amd64] https://packages.microsoft.com/repos/amlfs-${osReleaseCodeName}/ ${osReleaseCodeName} main" | tee /etc/apt/sources.list.d/amlfs.list
     apt-get update


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:
In addition to check /etc/apt/sources.list.d/amlfs.list exists we need to check if the apt-update is successful. This will help us recover the pod in-case of restarts during apt-update or failure in apt-update there by not leading the pod in an irrecoverable state.

**Which issue(s) this PR fixes**:
Issue  https://github.com/kubernetes-sigs/azurelustre-csi-driver/issues/141
