### PR TITLE
Uninstall existing driver if upgrade fails

### DIFF
--- a/deploy/csi-azurelustre-node.yaml
+++ b/deploy/csi-azurelustre-node.yaml
@@ -58,10 +58,6 @@ spec:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
             - --v=2
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/azurelustre.csi.azure.com-reg.sock /csi/csi.sock"]
           livenessProbe:
             exec:
               command:
@@ -90,6 +86,10 @@ spec:
         - name: azurelustre
           image: mcr.microsoft.com/oss/kubernetes-csi/azurelustre-csi:v0.1.12
           imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "lustre_rmmod"]
           args:
             - "-v=5"
             - "--endpoint=$(CSI_ENDPOINT)"
@@ -117,6 +117,8 @@ spec:
               value: "yes"
             - name: LUSTRE_VERSION
               value: "2.15.1"
+            - name: CLIENT_SHA_SUFFIX
+              value: "33-g0168b83"
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
We currently don't have a supported in-place upgrade path for users because of the way our packages are configured. There are a number of ways that the installed packages can get into bad states that apt (and even dpkg directly) refuses to work around without manual intervention.

To avoid this behavior, this commit adds limited retries to the package installation step that, in the instance of a failed client install, will attempt to unload any running Lustre modules, remove the installed packages, and retry the installation.

In addition, when the pod is terminated, it will attempt to unload the Lustre modules, but will not fail if it cannot unload them (such as when there are existing pods running which have active Lustre mounts).

If it cannot unload the existing modules, it will log a warning that the new version will likely not be running, but will not fail. Additionally, if it cannot install the desired packages, it will log a warning that it could not install correctly, but will continue to attempt to start the driver.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
Tested this with:
- upgrading and downgrading the SHA (succeeds after first failed try)
- with a known bad state (succeeds after first failed try)
- with an existing, correctly installed driver of the expected version (succeeds on first try with no retries)
- from a clean state with no driver installed (succeeds on first try with no retries)

**Release note**:
```
none
```
