### PR TITLE
Add sub-dir functionality

### DIFF
--- a/deploy/csi-azurelustre-controller.yaml
+++ b/deploy/csi-azurelustre-controller.yaml
@@ -34,7 +34,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
             - "--timeout=60s"
-            - "--extra-create-metadata=false"
+            - "--extra-create-metadata=true"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/docs/examples/pod_echo_date_subdir.yaml
+++ b/docs/examples/pod_echo_date_subdir.yaml
@@ -1,4 +1,7 @@
 ---
+# The subdirectory functionality is not yet released; these files are
+# provided as examples for the next version of this driver. This message
+# will be removed at release time when we make this new release the default
 kind: Pod
 apiVersion: v1
 metadata:

--- a/docs/examples/pod_echo_date_subdir.yaml
+++ b/docs/examples/pod_echo_date_subdir.yaml
@@ -1,0 +1,22 @@
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: lustre-echo-date-subdir
+spec:
+  nodeSelector:
+    "kubernetes.io/os": linux
+  containers:
+    - image: busybox
+      name: lustre-echo-date
+      command:
+        - "/bin/sh"
+        - "-c"
+        - while true; do echo $(date) >> /mnt/lustre/outfile; sleep 1; done
+      volumeMounts:
+        - name: lustre-subdir
+          mountPath: "/mnt/lustre"
+  volumes:
+    - name: lustre-subdir
+      persistentVolumeClaim:
+        claimName: pvc-lustre-subdir

--- a/docs/examples/pv_subdir.yaml
+++ b/docs/examples/pv_subdir.yaml
@@ -1,4 +1,7 @@
 ---
+# The subdirectory functionality is not yet released; these files are
+# provided as examples for the next version of this driver. This message
+# will be removed at release time when we make this new release the default
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -21,6 +24,7 @@ spec:
       # The subdirectory to create and mount per pod (cannot use pvc / pv metadata in static volumes)
       sub-dir: "${pod.metadata.namespace}_${pod.metadata.name}"
       # Whether the created subdirectory should be retained or deleted at pod exit
+      # This parameter is required if "sub-dir" is provided
       retain-sub-dir: "false"
     # Make sure this VolumeID is unique in the cluster
     volumeHandle: ${UNIQUE_IDENTIFIER_VOLUME_ID}

--- a/docs/examples/pv_subdir.yaml
+++ b/docs/examples/pv_subdir.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  # The name of the PV
+  name: pv-lustre-subdir
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    # This field should be the true size of the Azure Lustre you want
+    # to used. So that, k8s can allocate resources better.
+    storage: 4Ti
+  csi:
+    driver: azurelustre.csi.azure.com
+    volumeAttributes:
+      # The file system name of the existing Lustre
+      fs-name: ${EXISTING_LUSTRE_FS_NAME}
+      # The IP address of the existing Lustre
+      mgs-ip-address: ${EXISTING_LUSTRE_IP_ADDRESS}
+      # The subdirectory to create and mount per pod (cannot use pvc / pv metadata in static volumes)
+      sub-dir: "${pod.metadata.namespace}_${pod.metadata.name}"
+      # Whether the created subdirectory should be retained or deleted at pod exit
+      retain-sub-dir: "false"
+    # Make sure this VolumeID is unique in the cluster
+    volumeHandle: ${UNIQUE_IDENTIFIER_VOLUME_ID}
+  # "Delete" is not supported in static provisioning PV
+  mountOptions:
+    - noatime
+    - flock
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""

--- a/docs/examples/pvc_pv_subdir.yaml
+++ b/docs/examples/pvc_pv_subdir.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  # The name of the PVC
+  name: pvc-lustre-subdir
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Mi
+  # This field must be the same as PV name in PersistentVolume.
+  volumeName: pv-lustre-subdir
+  storageClassName: ""

--- a/docs/examples/pvc_pv_subdir.yaml
+++ b/docs/examples/pvc_pv_subdir.yaml
@@ -1,4 +1,7 @@
 ---
+# The subdirectory functionality is not yet released; these files are
+# provided as examples for the next version of this driver. This message
+# will be removed at release time when we make this new release the default
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/docs/examples/pvc_storageclass_subdir.yaml
+++ b/docs/examples/pvc_storageclass_subdir.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  # The name of the PVC
+  name: pvc-lustre-subdir
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      # The real storage capacity in the claim
+      storage: 1Gi
+  # This field must be the same as the storage class name in StorageClass
+  storageClassName: subdir.azurelustre.csi.azure.com

--- a/docs/examples/pvc_storageclass_subdir.yaml
+++ b/docs/examples/pvc_storageclass_subdir.yaml
@@ -1,4 +1,7 @@
 ---
+# The subdirectory functionality is not yet released; these files are
+# provided as examples for the next version of this driver. This message
+# will be removed at release time when we make this new release the default
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/docs/examples/storageclass_existing_lustre_subdir.yaml
+++ b/docs/examples/storageclass_existing_lustre_subdir.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  # The name of the StorageClass.
+  name: subdir.azurelustre.csi.azure.com
+parameters:
+  # The file system name of the existing Lustre, "lustrefs" in common case
+  fs-name: ${EXISTING_LUSTRE_FS_NAME}
+  # The IP address of the existing Lustre
+  mgs-ip-address: ${EXISTING_LUSTRE_IP_ADDRESS}
+  # The subdirectory to create and mount per pod
+  sub-dir: "${pvc.metadata.name}_${pod.metadata.name}"
+  # Whether the created subdirectory should be retained or deleted at pod exit
+  retain-sub-dir: "false"
+provisioner: azurelustre.csi.azure.com
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+mountOptions:
+  - noatime
+  - flock

--- a/docs/examples/storageclass_existing_lustre_subdir.yaml
+++ b/docs/examples/storageclass_existing_lustre_subdir.yaml
@@ -1,4 +1,7 @@
 ---
+# The subdirectory functionality is not yet released; these files are
+# provided as examples for the next version of this driver. This message
+# will be removed at release time when we make this new release the default
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -12,6 +15,7 @@ parameters:
   # The subdirectory to create and mount per pod
   sub-dir: "${pvc.metadata.name}_${pod.metadata.name}"
   # Whether the created subdirectory should be retained or deleted at pod exit
+  # This parameter is required if "sub-dir" is provided
   retain-sub-dir: "false"
 provisioner: azurelustre.csi.azure.com
 reclaimPolicy: Delete

--- a/pkg/azurelustre/fake_mount.go
+++ b/pkg/azurelustre/fake_mount.go
@@ -28,36 +28,36 @@ type fakeMounter struct {
 }
 
 // Mount overrides mount.FakeMounter.Mount.
-func (f *fakeMounter) Mount(source string, target string, _ string, _ []string) error {
+func (f *fakeMounter) Mount(source string, target string, fstype string, options []string) error {
 	if strings.Contains(source, "ut-container") {
 		return fmt.Errorf("fake Mount: source error")
 	} else if strings.Contains(target, "error_mount") {
 		return fmt.Errorf("fake Mount: target error")
 	}
 
-	return nil
+	return f.FakeMounter.Mount(source, target, fstype, options)
 }
 
 // MountSensitive overrides mount.FakeMounter.MountSensitive.
-func (f *fakeMounter) MountSensitive(source string, target string, _ string, _ []string, _ []string) error {
+func (f *fakeMounter) MountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
 	if strings.Contains(source, "ut-container-sens") {
 		return fmt.Errorf("fake MountSensitive: source error")
 	} else if strings.Contains(target, "error_mount_sens") {
 		return fmt.Errorf("fake MountSensitive: target error")
 	}
 
-	return nil
+	return f.FakeMounter.MountSensitive(source, target, fstype, options, sensitiveOptions)
 }
 
 // MountSensitiveWithoutSystemdWithMountFlags overrides mount.FakeMounter.MountSensitiveWithoutSystemdWithMountFlags.
-func (f *fakeMounter) MountSensitiveWithoutSystemdWithMountFlags(source string, target string, _ string, _ []string, _ []string, _ []string) error {
+func (f *fakeMounter) MountSensitiveWithoutSystemdWithMountFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
 	if strings.Contains(source, "ut-container-sens-mountflags") {
 		return fmt.Errorf("fake MountSensitiveWithoutSystemdWithMountFlags: source error")
 	} else if strings.Contains(target, "error_mount_sens_mountflags") {
 		return fmt.Errorf("fake MountSensitiveWithoutSystemdWithMountFlags: target error")
 	}
 
-	return nil
+	return f.FakeMounter.MountSensitiveWithoutSystemdWithMountFlags(source, target, fstype, options, sensitiveOptions, mountFlags)
 }
 
 func (f *fakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {

--- a/pkg/azurelustre/identityserver_test.go
+++ b/pkg/azurelustre/identityserver_test.go
@@ -37,7 +37,7 @@ func TestGetPluginInfo(t *testing.T) {
 }
 
 func TestGetPluginInfo_Err_NoDriverName(t *testing.T) {
-	//Check error when driver name is empty
+	// Check error when driver name is empty
 	d := NewFakeDriver()
 	d.Name = ""
 	req := csi.GetPluginInfoRequest{}
@@ -51,7 +51,7 @@ func TestGetPluginInfo_Err_NoDriverName(t *testing.T) {
 }
 
 func TestGetPluginInfo_Err_NoVersion(t *testing.T) {
-	//Check error when version is empty
+	// Check error when version is empty
 	d := NewFakeDriver()
 	d.Version = ""
 	req := csi.GetPluginInfoRequest{}

--- a/pkg/azurelustre/nodeserver.go
+++ b/pkg/azurelustre/nodeserver.go
@@ -19,6 +19,8 @@ package azurelustre
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	volumehelper "sigs.k8s.io/azurelustre-csi-driver/pkg/util"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
@@ -52,8 +54,9 @@ func (d *Driver) NodePublishVolume(
 			"Volume capability missing in request")
 	}
 	userMountFlags := volCap.GetMount().GetMountFlags()
+
 	volumeID := req.GetVolumeId()
-	if len(req.GetVolumeId()) == 0 {
+	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument,
 			"Volume ID missing in request")
 	}
@@ -70,34 +73,108 @@ func (d *Driver) NodePublishVolume(
 			"Volume context must be provided")
 	}
 
-	mgsIPAddress, found := context[VolumeContextMGSIPAddress]
-	if !found {
-		return nil, status.Error(codes.InvalidArgument,
-			"Context mgs-ip-address must be provided")
+	vol, err := newLustreVolume(volumeID, context)
+	if err != nil {
+		return nil, err
 	}
 
-	azureLustreName, found := context[VolumeContextFSName]
-	if !found {
-		return nil, status.Error(codes.InvalidArgument,
-			"Context fs-name must be provided")
+	vol.id = volumeID
+
+	subDirReplaceMap := map[string]string{}
+
+	// get metadata values
+	for k, v := range context {
+		switch strings.ToLower(k) {
+		case podNameKey:
+			subDirReplaceMap[podNameMetadata] = v
+		case podNamespaceKey:
+			subDirReplaceMap[podNamespaceMetadata] = v
+		case podUIDKey:
+			subDirReplaceMap[podUIDMetadata] = v
+		case serviceAccountNameKey:
+			subDirReplaceMap[serviceAccountNameMetadata] = v
+		case pvcNamespaceKey:
+			subDirReplaceMap[pvcNamespaceMetadata] = v
+		case pvcNameKey:
+			subDirReplaceMap[pvcNameMetadata] = v
+		case pvNameKey:
+			subDirReplaceMap[pvNameMetadata] = v
+		}
 	}
+
+	if acquired := d.volumeLocks.TryAcquire(vol.id); !acquired {
+		return nil, status.Errorf(codes.Aborted,
+			volumeOperationAlreadyExistsFmt,
+			vol.id)
+	}
+	defer d.volumeLocks.Release(vol.id)
 
 	isOperationSucceeded := false
 	defer func() {
 		mc.ObserveOperationWithResult(isOperationSucceeded)
 	}()
 
-	source := fmt.Sprintf("%s@tcp:/%s", mgsIPAddress, azureLustreName)
+	source := getSourceString(vol.mgsIPAddress, vol.azureLustreName)
+
+	readOnly := false
 
 	mountOptions := []string{}
 	if req.GetReadonly() {
+		readOnly = true
 		mountOptions = append(mountOptions, "ro")
 	}
 	for _, userMountFlag := range userMountFlags {
-		if userMountFlag == "ro" && req.GetReadonly() {
-			continue
+		if userMountFlag == "ro" {
+			readOnly = true
+
+			if req.GetReadonly() {
+				continue
+			}
 		}
 		mountOptions = append(mountOptions, userMountFlag)
+	}
+
+	if len(vol.subDir) > 0 && !d.enableAzureLustreMockMount {
+		if readOnly && !vol.retainSubDir {
+			return nil, status.Error(
+				codes.InvalidArgument,
+				"Context retain-sub-dir must be true for a sub-dir on a read-only volume",
+			)
+		}
+
+		interpolatedSubDir := replaceWithMap(vol.subDir, subDirReplaceMap)
+
+		isSubpath, err := ensureStrictSubpath(source, interpolatedSubDir)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal,
+				"failed to determine if %q is a strict subpath of %q: %v", interpolatedSubDir, source, err)
+		}
+
+		if !isSubpath {
+			return nil, status.Error(
+				codes.InvalidArgument,
+				"Context sub-dir must be strict subpath",
+			)
+		}
+
+		if readOnly {
+			klog.V(2).Info("NodePublishVolume: not attempting to create sub-dir on read-only volume, assuming existing path")
+		} else {
+			klog.V(2).Infof(
+				"NodePublishVolume: sub-dir will be created at %q",
+				interpolatedSubDir,
+			)
+
+			if err = d.createSubDir(vol, interpolatedSubDir, mountOptions); err != nil {
+				return nil, err
+			}
+		}
+
+		source = filepath.Join(source, interpolatedSubDir)
+		klog.V(2).Infof(
+			"NodePublishVolume: full mount source with sub-dir: %q",
+			source,
+		)
 	}
 
 	mnt, err := d.ensureMountPoint(target)
@@ -179,27 +256,93 @@ func (d *Driver) NodeUnpublishVolume(
 		"",
 		d.Name)
 
-	if len(req.GetVolumeId()) == 0 {
+	volumeID := req.GetVolumeId()
+	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument,
 			"Volume ID missing in request")
 	}
-	if len(req.GetTargetPath()) == 0 {
+
+	targetPath := req.GetTargetPath()
+	if len(targetPath) == 0 {
 		return nil, status.Error(codes.InvalidArgument,
 			"Target path missing in request")
 	}
+
+	if acquired := d.volumeLocks.TryAcquire(volumeID); !acquired {
+		return nil, status.Errorf(codes.Aborted,
+			volumeOperationAlreadyExistsFmt,
+			volumeID)
+	}
+	defer d.volumeLocks.Release(volumeID)
 
 	isOperationSucceeded := false
 	defer func() {
 		mc.ObserveOperationWithResult(isOperationSucceeded)
 	}()
 
-	targetPath := req.GetTargetPath()
-	volumeID := req.GetVolumeId()
+	cleanupSubDir := false
+
+	sourceRoot := ""
+	subDirToClean := ""
+
+	var mountOptions []string
+
+	vol, err := getLustreVolFromID(volumeID)
+	if err != nil {
+		klog.V(2).Infof("failed to parse volume id %q for sub-dir cleanup, skipping", volumeID)
+	} else if len(vol.subDir) > 0 && !vol.retainSubDir {
+		cleanupSubDir = true
+		sourceRoot = getSourceString(vol.mgsIPAddress, vol.azureLustreName)
+	}
+
+	if cleanupSubDir {
+		foundMountPoint := false
+		sourceWithSubDir := ""
+
+		mountPoints, _ := d.mounter.List()
+		for _, mountPoint := range mountPoints {
+			if mountPoint.Path == targetPath {
+				sourceWithSubDir = mountPoint.Device
+				foundMountPoint = true
+
+				mountOptions = mountPoint.Opts
+				for _, option := range mountOptions {
+					if option == "ro" {
+						klog.Warning("mounted volume is read only, not attempting to clean up sub-dir")
+
+						cleanupSubDir = false
+					}
+				}
+			}
+		}
+
+		switch {
+		case !foundMountPoint:
+			klog.Warningf("Warning: could not find source for mount point: %q. Skipping sub-dir delete", targetPath)
+
+			cleanupSubDir = false
+		case !strings.HasPrefix(sourceWithSubDir, sourceRoot):
+			klog.Warningf("Warning: mounted directory %q doesn't appear to be subdirectory of %q. Skipping sub-dir delete",
+				sourceWithSubDir,
+				sourceRoot,
+			)
+
+			cleanupSubDir = false
+		case len(strings.TrimPrefix(sourceWithSubDir, sourceRoot)) == 0:
+			klog.Warningf("Warning: mounted directory %q isn't a subdirectory of Lustre root. Skipping sub-dir delete",
+				sourceWithSubDir,
+			)
+
+			cleanupSubDir = false
+		default:
+			subDirToClean = strings.TrimPrefix(sourceWithSubDir, sourceRoot)
+		}
+	}
 
 	klog.V(2).Infof("NodeUnpublishVolume: unmounting volume %s on %s",
 		volumeID, targetPath)
 	d.kernelModuleLock.Lock()
-	err := mount.CleanupMountPoint(targetPath, d.mounter,
+	err = mount.CleanupMountPoint(targetPath, d.mounter,
 		true /*extensiveMountPointCheck*/)
 	d.kernelModuleLock.Unlock()
 	if err != nil {
@@ -211,6 +354,20 @@ func (d *Driver) NodeUnpublishVolume(
 		volumeID,
 		targetPath,
 	)
+
+	if cleanupSubDir {
+		klog.V(2).Infof(
+			"NodeUnpublishVolume: deleting subdirectory %q within %q",
+			subDirToClean,
+			sourceRoot,
+		)
+
+		if err = d.deleteSubDir(vol, subDirToClean, mountOptions); err != nil {
+			return nil, err
+		}
+	} else {
+		klog.V(2).Info("Not attempting to clean sub-dir")
+	}
 
 	isOperationSucceeded = true
 
@@ -356,4 +513,360 @@ func (d *Driver) ensureMountPoint(target string) (bool, error) {
 		return !notMnt, err
 	}
 	return !notMnt, nil
+}
+
+func (d *Driver) createSubDir(vol *lustreVolume, subDirPath string, mountOptions []string) error {
+	if err := d.internalMount(vol, mountOptions); err != nil {
+		return err
+	}
+
+	defer func() {
+		if err := d.internalUnmount(vol); err != nil {
+			klog.Warningf("failed to unmount lustre server: %v", err.Error())
+		}
+	}()
+
+	internalVolumePath, err := getInternalVolumePath(d.workingMountDir, vol, subDirPath)
+	if err != nil {
+		return err
+	}
+
+	klog.V(2).Infof("Making subdirectory at %q", internalVolumePath)
+
+	if err := os.MkdirAll(internalVolumePath, 0775); err != nil {
+		return status.Errorf(codes.Internal, "failed to make subdirectory: %v", err.Error())
+	}
+
+	return nil
+}
+
+func (d *Driver) deleteSubDir(vol *lustreVolume, subDirPath string, mountOptions []string) error {
+	if err := d.internalMount(vol, mountOptions); err != nil {
+		return err
+	}
+
+	defer func() {
+		if err := d.internalUnmount(vol); err != nil {
+			klog.Warningf("failed to unmount lustre server: %v", err.Error())
+		}
+	}()
+
+	internalVolumePath, err := getInternalVolumePath(d.workingMountDir, vol, subDirPath)
+	if err != nil {
+		return err
+	}
+
+	klog.V(2).Infof("Removing subdirectory at %q", internalVolumePath)
+
+	if err = os.RemoveAll(internalVolumePath); err != nil {
+		return status.Errorf(codes.Internal, "failed to delete subdirectory: %v", err.Error())
+	}
+
+	return nil
+}
+
+func getSourceString(mgsIPAddress, azureLustreName string) string {
+	return fmt.Sprintf("%s@tcp:/%s", mgsIPAddress, azureLustreName)
+}
+
+func getInternalMountPath(workingMountDir string, vol *lustreVolume) (string, error) {
+	if vol == nil || len(vol.id) == 0 {
+		return "", status.Error(codes.Internal, "cannot get internal mount path for nil or empty volume")
+	}
+
+	isSubpath, err := ensureStrictSubpath(workingMountDir, vol.id)
+	if err != nil {
+		return "", status.Errorf(codes.Internal,
+			"failed to determine if %q is a strict subpath of %q: %v", vol.id, workingMountDir, err)
+	}
+
+	if !isSubpath {
+		return "", status.Errorf(
+			codes.InvalidArgument,
+			"volume name or id %q must be interpretable as a strict subpath",
+			vol.id,
+		)
+	}
+
+	return filepath.Join(workingMountDir, vol.id), nil
+}
+
+func getInternalVolumePath(workingMountDir string, vol *lustreVolume, subDirPath string) (string, error) {
+	internalMountPath, err := getInternalMountPath(workingMountDir, vol)
+	if err != nil {
+		return "", err
+	}
+
+	isSubpath, err := ensureStrictSubpath(internalMountPath, subDirPath)
+	if err != nil {
+		return "", status.Errorf(codes.Internal,
+			"failed to determine if %q is a strict subpath of %q: %v", subDirPath, internalMountPath, err)
+	}
+
+	if !isSubpath {
+		return "", status.Errorf(
+			codes.InvalidArgument,
+			"sub-dir %q must be strict subpath",
+			subDirPath,
+		)
+	}
+
+	return filepath.Join(internalMountPath, subDirPath), nil
+}
+
+func (d *Driver) internalMount(vol *lustreVolume, mountOptions []string) error {
+	source := getSourceString(vol.mgsIPAddress, vol.azureLustreName)
+
+	target, err := getInternalMountPath(d.workingMountDir, vol)
+	if err != nil {
+		return err
+	}
+
+	klog.V(4).Infof("internally mounting %v", target)
+
+	mnt, err := d.ensureMountPoint(target)
+	if err != nil {
+		return status.Errorf(codes.Internal,
+			"Could not mount target %q: %v",
+			target,
+			err)
+	}
+
+	if mnt {
+		klog.Warningf(
+			"volume %q is already mounted on %q",
+			vol.id,
+			target,
+		)
+
+		err = d.internalUnmount(vol)
+		if err != nil {
+			return status.Errorf(codes.Internal,
+				"Could not unmount existing volume at %q: %v",
+				target,
+				err)
+		}
+	}
+
+	klog.V(2).Infof(
+		"volume %q mounting %q at %q with mountOptions: %v",
+		vol.id, source, target, mountOptions,
+	)
+
+	d.kernelModuleLock.Lock()
+	err = d.mounter.MountSensitiveWithoutSystemdWithMountFlags(
+		source,
+		target,
+		"lustre",
+		mountOptions,
+		nil,
+		[]string{"--no-mtab"},
+	)
+	d.kernelModuleLock.Unlock()
+
+	if err != nil {
+		if removeErr := os.Remove(target); removeErr != nil {
+			return status.Errorf(
+				codes.Internal,
+				"Could not remove mount target %q: %v",
+				target,
+				removeErr,
+			)
+		}
+
+		return status.Errorf(codes.Internal,
+			"Could not mount %q at %q: %v", source, target, err)
+	}
+
+	return nil
+}
+
+func (d *Driver) internalUnmount(vol *lustreVolume) error {
+	target, err := getInternalMountPath(d.workingMountDir, vol)
+	if err != nil {
+		return err
+	}
+
+	klog.V(4).Infof("internally unmounting %v", target)
+
+	err = mount.CleanupMountPoint(target, d.mounter, true)
+	if err != nil {
+		err = status.Errorf(codes.Internal, "failed to unmount staging target %q: %v", target, err)
+	}
+
+	return err
+}
+
+func ensureStrictSubpath(basePath, subPath string) (bool, error) {
+	absoluteBasePath, err := filepath.Abs(basePath)
+	if err != nil {
+		return false, status.Errorf(codes.Internal, "failed to find absolute path for base path directory: %v", err.Error())
+	}
+
+	absoluteSubPath, err := filepath.Abs(filepath.Join(absoluteBasePath, subPath))
+	if err != nil {
+		return false, status.Errorf(codes.Internal, "failed to find absolute path for sub path directory: %v", err.Error())
+	}
+
+	if !strings.HasPrefix(absoluteSubPath, absoluteBasePath) {
+		return false, nil
+	}
+
+	if absoluteSubPath == absoluteBasePath {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+type lustreVolume struct {
+	name            string
+	id              string
+	mgsIPAddress    string
+	azureLustreName string
+	subDir          string
+	retainSubDir    bool
+}
+
+func getLustreVolFromID(id string) (*lustreVolume, error) {
+	segments := strings.Split(id, separator)
+	if len(segments) < 3 {
+		return nil, fmt.Errorf("could not split volume id %q into lustre name and ip address", id)
+	}
+
+	name := segments[0]
+	vol := &lustreVolume{
+		name:            name,
+		id:              id,
+		azureLustreName: strings.Trim(segments[1], "/"),
+		mgsIPAddress:    segments[2],
+	}
+
+	if len(segments) >= 4 {
+		vol.subDir = strings.Trim(segments[3], "/")
+
+		retainSubDirString := strings.ToLower(segments[4])
+		if len(retainSubDirString) == 0 {
+			vol.retainSubDir = true
+		} else {
+			if retainSubDirString != "true" && retainSubDirString != "false" {
+				return nil, fmt.Errorf("could not parse retain-sub-dir value %q into boolean", retainSubDirString)
+			}
+			vol.retainSubDir = retainSubDirString == "true"
+		}
+	} else {
+		vol.retainSubDir = true
+	}
+
+	return vol, nil
+}
+
+// Convert context parameters to a lustreVolume
+func newLustreVolume(volumeID string, params map[string]string) (*lustreVolume, error) {
+	var mgsIPAddress, azureLustreName, subDir string
+	// Shouldn't attempt to delete anything unless sub-dir is actually specified
+	retainSubDir := true
+	subDirReplaceMap := map[string]string{}
+	// validate parameters (case-insensitive).
+	for k, v := range params {
+		switch strings.ToLower(k) {
+		case VolumeContextMGSIPAddress:
+			mgsIPAddress = v
+		case VolumeContextFSName:
+			azureLustreName = v
+		case VolumeContextSubDir:
+			subDir = v
+			subDir = strings.Trim(subDir, "/")
+
+			if len(subDir) == 0 {
+				return nil, status.Error(
+					codes.InvalidArgument,
+					"Context sub-dir must not be empty or root if provided",
+				)
+			}
+
+			if _, ok := params[VolumeContextRetainSubDir]; !ok {
+				return nil, status.Error(
+					codes.InvalidArgument,
+					"Context retain-sub-dir must be provided when sub-dir is provided",
+				)
+			}
+		case VolumeContextRetainSubDir:
+			retainSubDirString := strings.ToLower(v)
+			if retainSubDirString != "true" && retainSubDirString != "false" {
+				return nil, status.Error(
+					codes.InvalidArgument,
+					"Context retain-sub-dir value must be either true or false",
+				)
+			}
+
+			retainSubDir = retainSubDirString == "true"
+
+			if _, ok := params[VolumeContextSubDir]; !ok {
+				return nil, status.Error(
+					codes.InvalidArgument,
+					"Context sub-dir must be provided when retain-sub-dir is provided",
+				)
+			}
+		case podNameKey:
+			subDirReplaceMap[podNameMetadata] = v
+		case podNamespaceKey:
+			subDirReplaceMap[podNamespaceMetadata] = v
+		case podUIDKey:
+			subDirReplaceMap[podUIDMetadata] = v
+		case serviceAccountNameKey:
+			subDirReplaceMap[serviceAccountNameMetadata] = v
+		case pvcNamespaceKey:
+			subDirReplaceMap[pvcNamespaceMetadata] = v
+		case pvcNameKey:
+			subDirReplaceMap[pvcNameMetadata] = v
+		case pvNameKey:
+			subDirReplaceMap[pvNameMetadata] = v
+		}
+	}
+
+	if len(mgsIPAddress) == 0 {
+		return nil, status.Error(
+			codes.InvalidArgument,
+			"Context mgs-ip-address must be provided",
+		)
+	}
+
+	azureLustreName = strings.Trim(azureLustreName, "/")
+	if len(azureLustreName) == 0 {
+		return nil, status.Error(
+			codes.InvalidArgument,
+			"Context fs-name must be provided",
+		)
+	}
+
+	volName := ""
+
+	volFromID, err := getLustreVolFromID(volumeID)
+	if err != nil {
+		klog.Warningf("error parsing volume id '%v'", err)
+	} else {
+		volName = volFromID.name
+	}
+
+	vol := &lustreVolume{
+		name:            volName,
+		mgsIPAddress:    mgsIPAddress,
+		azureLustreName: azureLustreName,
+		subDir:          subDir,
+		retainSubDir:    retainSubDir,
+		id: fmt.Sprintf(
+			volumeIDTemplate,
+			volName,
+			azureLustreName,
+			mgsIPAddress,
+			subDir,
+			retainSubDir),
+	}
+
+	if volFromID != nil && *volFromID != *vol {
+		klog.Warningf("volume context does not match values in volume id for volume %q", volumeID)
+	}
+
+	return vol, nil
 }

--- a/pkg/azurelustre/nodeserver_test.go
+++ b/pkg/azurelustre/nodeserver_test.go
@@ -925,62 +925,45 @@ func TestNodeGetVolumeStats(t *testing.T) {
 func TestEnsureStrictSubpath(t *testing.T) {
 	cases := []struct {
 		desc           string
-		basePath       string
 		subPath        string
-		expectedErr    error
 		expectedResult bool
 	}{
 		{
 			desc:           "valid subpath",
-			basePath:       "/basePath",
 			subPath:        "subPath",
-			expectedErr:    nil,
-			expectedResult: true,
-		},
-		{
-			desc:           "valid subpath with leading slash",
-			basePath:       "/basePath",
-			subPath:        "/subPath",
-			expectedErr:    nil,
 			expectedResult: true,
 		},
 		{
 			desc:           "valid subpath, does not actually get to parent",
-			basePath:       "/basePath",
 			subPath:        "subPath/../otherSubPath",
-			expectedErr:    nil,
 			expectedResult: true,
 		},
 		{
+			desc:           "invalid subpath, leading slash",
+			subPath:        "/subPath",
+			expectedResult: false,
+		},
+		{
 			desc:           "invalid subpath, attempts to go to parent",
-			basePath:       "/basePath",
 			subPath:        "../subPath",
-			expectedErr:    nil,
 			expectedResult: false,
 		},
 		{
 			desc:           "invalid subpath, same as parent",
-			basePath:       "/basePath",
 			subPath:        "./",
-			expectedErr:    nil,
 			expectedResult: false,
 		},
 		{
 			desc:           "invalid subpath, empty",
-			basePath:       "/basePath",
 			subPath:        "",
-			expectedErr:    nil,
 			expectedResult: false,
 		},
 	}
 	for _, test := range cases {
 		test := test // pin
 		t.Run(test.desc, func(t *testing.T) {
-			actualResult, err := ensureStrictSubpath(test.basePath, test.subPath)
+			actualResult := ensureStrictSubpath(test.subPath)
 
-			if !reflect.DeepEqual(err, test.expectedErr) {
-				t.Errorf("Desc: %v, Expected error: %v, Actual error: %v", test.desc, test.expectedErr, err)
-			}
 			assert.Equal(t, test.expectedResult, actualResult, "Desc: %s - Incorrect lustre volume: %v - Expected: %v", test.desc, actualResult, test.expectedResult)
 		})
 	}

--- a/pkg/azurelustre/nodeserver_test.go
+++ b/pkg/azurelustre/nodeserver_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"syscall"
 	"testing"
@@ -35,11 +36,9 @@ import (
 	testingexec "k8s.io/utils/exec/testing"
 )
 
-// TODO_JUSJIN: update and add tests
-
 const (
-	sourceTest = "./source_test"
-	targetTest = "./target_test"
+	targetTest = "target_test"
+	subDir     = "testSubDir"
 )
 
 func TestNodeGetInfo(t *testing.T) {
@@ -110,7 +109,6 @@ func TestEnsureMountPoint(t *testing.T) {
 	}
 
 	// Setup
-	_ = makeDir(alreadyExistTarget)
 	d := NewFakeDriver()
 	fakeMounter := &fakeMounter{}
 	fakeExec := &testingexec.FakeExec{ExactOrder: true}
@@ -120,246 +118,720 @@ func TestEnsureMountPoint(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		_, err := d.ensureMountPoint(test.target)
-		if !reflect.DeepEqual(err, test.expectedErr) {
-			t.Errorf("[%s]: Unexpected Error: %v, expected error: %v", test.desc, err, test.expectedErr)
-		}
-	}
+		test := test // pin
+		_ = makeDir(alreadyExistTarget)
 
-	// Clean up
-	err := os.RemoveAll(alreadyExistTarget)
-	assert.NoError(t, err)
-	err = os.RemoveAll(targetTest)
-	assert.NoError(t, err)
+		t.Run(test.desc, func(t *testing.T) {
+			_, err := d.ensureMountPoint(test.target)
+			if !reflect.DeepEqual(err, test.expectedErr) {
+				t.Errorf("Desc: %v, Expected error: %v, Actual error: %v", test.desc, test.expectedErr, err)
+			}
+		})
+
+		err := os.RemoveAll(alreadyExistTarget)
+		assert.NoError(t, err)
+		err = os.RemoveAll(targetTest)
+		assert.NoError(t, err)
+	}
 }
 
 func TestNodePublishVolume(t *testing.T) {
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Errorf("failed to get current working directory")
+	}
+
+	workingMountDir := filepath.Join(workingDirectory, "workingMountDir")
+
 	volumeCap := csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER}
 	alreadyExistTarget := "./false_is_likely_exist_target"
+	metadataVolumeID := "vol_1#lustrefs#1.1.1.1#testNestedSubDir/${pod.metadata.name}/${pod.metadata.namespace}/${pod.metadata.uid}/${serviceAccount.metadata.name}/${pvc.metadata.name}/${pvc.metadata.namespace}/${pv.metadata.name}/testNestedSubDir#false"
 	createDirError := status.Errorf(codes.Internal,
 		"Could not mount target \"./azurelustre.go\": mkdir ./azurelustre.go: not a directory")
 	tests := []struct {
-		desc        string
-		setup       func(*Driver)
-		req         csi.NodePublishVolumeRequest
-		expectedErr error
-		cleanup     func(*Driver)
+		desc                 string
+		setup                func(*Driver)
+		req                  csi.NodePublishVolumeRequest
+		expectedErr          error
+		expectedMountpoints  []mount.MountPoint
+		expectedMountActions []mount.FakeAction
+		cleanup              func(*Driver)
 	}{
 		{
-			desc:        "Volume capabilities missing",
-			req:         csi.NodePublishVolumeRequest{},
-			expectedErr: status.Error(codes.InvalidArgument, "Volume capability missing in request"),
+			desc:                 "Volume capabilities missing",
+			req:                  csi.NodePublishVolumeRequest{},
+			expectedErr:          status.Error(codes.InvalidArgument, "Volume capability missing in request"),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
 		},
 		{
-			desc:        "Volume ID missing",
-			req:         csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap}},
-			expectedErr: status.Error(codes.InvalidArgument, "Volume ID missing in request"),
-		},
-		{
-			desc: "Stage target path missing",
-			req: csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
-				VolumeId: "vol_1"},
-			expectedErr: status.Error(codes.InvalidArgument, "Target path not provided"),
+			desc:                 "Volume ID missing",
+			req:                  csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap}},
+			expectedErr:          status.Error(codes.InvalidArgument, "Volume ID missing in request"),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
 		},
 		{
 			desc: "Volume context missing",
-			req: csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
-				VolumeId:   "vol_1",
-				TargetPath: targetTest,
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1##",
+				TargetPath:       targetTest,
 			},
-			expectedErr: status.Error(codes.InvalidArgument, "Volume context must be provided"),
+			expectedErr:          status.Error(codes.InvalidArgument, "Volume context must be provided"),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
+		},
+		{
+			desc: "Target path missing",
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1#lustrefs#",
+				VolumeContext:    map[string]string{"fs-name": "lustrefs"},
+			},
+			expectedErr:          status.Error(codes.InvalidArgument, "Target path not provided"),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
 		},
 		{
 			desc: "MGS IP address missing",
-			req: csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
-				VolumeId:      "vol_1",
-				TargetPath:    targetTest,
-				VolumeContext: map[string]string{"fs-name": "lustrefs"}},
-			expectedErr: status.Error(codes.InvalidArgument, "Context mgs-ip-address must be provided"),
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1#lustrefs#",
+				TargetPath:       targetTest,
+				VolumeContext:    map[string]string{"fs-name": "lustrefs"},
+			},
+			expectedErr:          status.Error(codes.InvalidArgument, "Context mgs-ip-address must be provided"),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
 		},
 		{
 			desc: "FS name missing",
-			req: csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
-				VolumeId:      "vol_1",
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1##1.1.1.1",
+				TargetPath:       targetTest,
+				VolumeContext:    map[string]string{"mgs-ip-address": "1.1.1.1"},
+			},
+			expectedErr:          status.Error(codes.InvalidArgument, "Context fs-name must be provided"),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
+		},
+		{
+			desc: "Invalid retain-sub-dir",
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1#lustrefs#1.1.1.1#testSubDir#f",
+				TargetPath:       targetTest,
+				VolumeContext:    map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": subDir, "retain-sub-dir": "f"},
+			},
+			expectedErr:          status.Error(codes.InvalidArgument, "Context retain-sub-dir value must be either true or false"),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
+		},
+		{
+			desc: "Valid request with old ID",
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock"}},
+				}},
+				VolumeId:      "vol_1#lustrefs#1.1.1.1",
 				TargetPath:    targetTest,
-				VolumeContext: map[string]string{"mgs-ip-address": "1.1.1.1"}},
-			expectedErr: status.Error(codes.InvalidArgument, "Context fs-name must be provided"),
+				VolumeContext: map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs"},
+			},
+			expectedErr:          nil,
+			expectedMountpoints:  []mount.MountPoint{{Device: "1.1.1.1@tcp:/lustrefs", Path: "target_test", Type: "lustre", Opts: []string{"noatime", "flock"}}},
+			expectedMountActions: []mount.FakeAction{{Action: "mount", Target: "target_test", Source: "1.1.1.1@tcp:/lustrefs", FSType: "lustre"}},
+		},
+		{
+			desc: "Empty sub-dir",
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1#lustrefs#1.1.1.1##false",
+				TargetPath:       targetTest,
+				VolumeContext:    map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": "", "retain-sub-dir": "false"},
+				Readonly:         false,
+			},
+			expectedErr:          status.Error(codes.InvalidArgument, "Context sub-dir must not be empty or root if provided"),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
+		},
+		{
+			desc: "Invalid root sub-dir",
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1#lustrefs#1.1.1.1#/#false",
+				TargetPath:       targetTest,
+				VolumeContext:    map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": "/", "retain-sub-dir": "false"},
+				Readonly:         false,
+			},
+			expectedErr:          status.Error(codes.InvalidArgument, "Context sub-dir must not be empty or root if provided"),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
+		},
+		{
+			desc: "Invalid sub-dir to parent",
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1#lustrefs#1.1.1.1#../../parentAttemptSubDir#false",
+				TargetPath:       targetTest,
+				VolumeContext:    map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": "../../parentAttemptSubDir", "retain-sub-dir": "false"},
+				Readonly:         false,
+			},
+			expectedErr:          status.Error(codes.InvalidArgument, "Context sub-dir must be strict subpath"),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
+		},
+		{
+			desc: "Invalid attempt to delete sub-dir on read only mount",
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock"}},
+				}},
+				VolumeId:      "vol_1#lustrefs#1.1.1.1#testSubDir#false",
+				TargetPath:    targetTest,
+				VolumeContext: map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": subDir, "retain-sub-dir": "false"},
+				Readonly:      true,
+			},
+			expectedErr:          status.Error(codes.InvalidArgument, "Context retain-sub-dir must be true for a sub-dir on a read-only volume"),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
 		},
 		{
 			desc: "Valid request read only",
-			req: csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
-				VolumeId:          "vol_1",
-				TargetPath:        targetTest,
-				StagingTargetPath: sourceTest,
-				VolumeContext:     map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs"},
-				Readonly:          true},
-			expectedErr: nil,
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock"}},
+				}},
+				VolumeId:      "vol_1#lustrefs#1.1.1.1#testSubDir#true",
+				TargetPath:    targetTest,
+				VolumeContext: map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": subDir, "retain-sub-dir": "true"},
+				Readonly:      true,
+			},
+			expectedErr:          nil,
+			expectedMountpoints:  []mount.MountPoint{{Device: "1.1.1.1@tcp:/lustrefs/testSubDir", Path: "target_test", Type: "lustre", Opts: []string{"ro", "noatime", "flock"}}},
+			expectedMountActions: []mount.FakeAction{{Action: "mount", Target: "target_test", Source: "1.1.1.1@tcp:/lustrefs/testSubDir", FSType: "lustre"}},
 		},
 		{
-			desc: "Valid mount options",
-			req: csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
-				Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock"}},
-			}},
-				VolumeId:          "vol_1",
-				TargetPath:        targetTest,
-				StagingTargetPath: sourceTest,
-				VolumeContext:     map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs"},
-				Readonly:          false},
-			expectedErr: nil,
+			desc: "Valid mount options, no sub-dir",
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock"}},
+				}},
+				VolumeId:      "vol_1#lustrefs#1.1.1.1##true",
+				TargetPath:    targetTest,
+				VolumeContext: map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs"},
+				Readonly:      false,
+			},
+			expectedErr:          nil,
+			expectedMountpoints:  []mount.MountPoint{{Device: "1.1.1.1@tcp:/lustrefs", Path: "target_test", Type: "lustre", Opts: []string{"noatime", "flock"}}},
+			expectedMountActions: []mount.FakeAction{{Action: "mount", Target: "target_test", Source: "1.1.1.1@tcp:/lustrefs", FSType: "lustre"}},
+		},
+		{
+			desc: "Valid mount options with sub-dir cleanup",
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock"}},
+				}},
+				VolumeId:      "vol_1#lustrefs#1.1.1.1#testSubDir#false",
+				TargetPath:    targetTest,
+				VolumeContext: map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": subDir, "retain-sub-dir": "false"},
+				Readonly:      false,
+			},
+			expectedErr:         nil,
+			expectedMountpoints: []mount.MountPoint{{Device: "1.1.1.1@tcp:/lustrefs/testSubDir", Path: "target_test", Type: "lustre", Opts: []string{"noatime", "flock"}}},
+			expectedMountActions: []mount.FakeAction{
+				{Action: "mount", Target: workingMountDir + "/vol_1#lustrefs#1.1.1.1#testSubDir#false", Source: "1.1.1.1@tcp:/lustrefs", FSType: "lustre"},
+				{Action: "unmount", Target: workingMountDir + "/vol_1#lustrefs#1.1.1.1#testSubDir#false", Source: "", FSType: ""},
+				{Action: "mount", Target: "target_test", Source: "1.1.1.1@tcp:/lustrefs/testSubDir", FSType: "lustre"},
+			},
+		},
+		{
+			desc: "Valid mount options with slashes in paths",
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock"}},
+				}},
+				VolumeId:      "vol_1#lustrefs#1.1.1.1#testSubDir#false",
+				TargetPath:    targetTest,
+				VolumeContext: map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs/", "sub-dir": "/testSubDir/", "retain-sub-dir": "false"},
+				Readonly:      false,
+			},
+			expectedErr:         nil,
+			expectedMountpoints: []mount.MountPoint{{Device: "1.1.1.1@tcp:/lustrefs/testSubDir", Path: "target_test", Type: "lustre", Opts: []string{"noatime", "flock"}}},
+			expectedMountActions: []mount.FakeAction{
+				{Action: "mount", Target: workingMountDir + "/vol_1#lustrefs#1.1.1.1#testSubDir#false", Source: "1.1.1.1@tcp:/lustrefs", FSType: "lustre"},
+				{Action: "unmount", Target: workingMountDir + "/vol_1#lustrefs#1.1.1.1#testSubDir#false", Source: "", FSType: ""},
+				{Action: "mount", Target: "target_test", Source: "1.1.1.1@tcp:/lustrefs/testSubDir", FSType: "lustre"},
+			},
 		},
 		{
 			desc: "Valid mount options with readonly",
-			req: csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
-				Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock"}},
-			}},
-				VolumeId:          "vol_1",
-				TargetPath:        targetTest,
-				StagingTargetPath: sourceTest,
-				VolumeContext:     map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs"},
-				Readonly:          true},
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock"}},
+				}},
+				VolumeId:      "vol_1#lustrefs#1.1.1.1#testSubDir#true",
+				TargetPath:    targetTest,
+				VolumeContext: map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": subDir, "retain-sub-dir": "true"},
+				Readonly:      true,
+			},
+			expectedErr:          nil,
+			expectedMountpoints:  []mount.MountPoint{{Device: "1.1.1.1@tcp:/lustrefs/testSubDir", Path: "target_test", Type: "lustre", Opts: []string{"ro", "noatime", "flock"}}},
+			expectedMountActions: []mount.FakeAction{{Action: "mount", Target: "target_test", Source: "1.1.1.1@tcp:/lustrefs/testSubDir", FSType: "lustre"}},
+		},
+		{
+			desc: "Valid mount options with metadata",
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock"}},
+				}},
+				VolumeId:   metadataVolumeID,
+				TargetPath: targetTest,
+				VolumeContext: map[string]string{
+					"mgs-ip-address":                         "1.1.1.1",
+					"fs-name":                                "lustrefs",
+					"sub-dir":                                "testNestedSubDir/${pod.metadata.name}/${pod.metadata.namespace}/${pod.metadata.uid}/${serviceAccount.metadata.name}/${pvc.metadata.name}/${pvc.metadata.namespace}/${pv.metadata.name}/testNestedSubDir",
+					"retain-sub-dir":                         "false",
+					"csi.storage.k8s.io/pod.name":            "testPodName",
+					"csi.storage.k8s.io/pod.namespace":       "testPodNamespace",
+					"csi.storage.k8s.io/pod.uid":             "testPodUid",
+					"csi.storage.k8s.io/serviceAccount.name": "testServiceAccountName",
+					"csi.storage.k8s.io/pvc/name":            "testPvcName",
+					"csi.storage.k8s.io/pvc/namespace":       "testPvcNamespace",
+					"csi.storage.k8s.io/pv/name":             "testPvName",
+				},
+				Readonly: false,
+			},
 			expectedErr: nil,
+			expectedMountpoints: []mount.MountPoint{
+				{
+					Device: "1.1.1.1@tcp:/lustrefs/testNestedSubDir/testPodName/testPodNamespace/testPodUid/testServiceAccountName/testPvcName/testPvcNamespace/testPvName/testNestedSubDir",
+					Path:   "target_test",
+					Type:   "lustre",
+					Opts:   []string{"noatime", "flock"},
+				},
+			},
+			expectedMountActions: []mount.FakeAction{
+				{Action: "mount", Target: filepath.Join(workingMountDir, metadataVolumeID), Source: "1.1.1.1@tcp:/lustrefs", FSType: "lustre"},
+				{Action: "unmount", Target: filepath.Join(workingMountDir, metadataVolumeID), Source: "", FSType: ""},
+				{
+					Action: "mount",
+					Target: "target_test",
+					Source: "1.1.1.1@tcp:/lustrefs/testNestedSubDir/testPodName/testPodNamespace/testPodUid/testServiceAccountName/testPvcName/testPvcNamespace/testPvName/testNestedSubDir",
+					FSType: "lustre",
+				},
+			},
 		},
 		{
 			desc: "Valid mount options with duplicated readonly",
-			req: csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
-				Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock", "ro"}},
-			}},
-				VolumeId:          "vol_1",
-				TargetPath:        targetTest,
-				StagingTargetPath: sourceTest,
-				VolumeContext:     map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs"},
-				Readonly:          true},
-			expectedErr: nil,
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock", "ro"}},
+				}},
+				VolumeId:      "vol_1#lustrefs#1.1.1.1#testSubDir#true",
+				TargetPath:    targetTest,
+				VolumeContext: map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": subDir, "retain-sub-dir": "true"},
+				Readonly:      true,
+			},
+			expectedErr:          nil,
+			expectedMountpoints:  []mount.MountPoint{{Device: "1.1.1.1@tcp:/lustrefs/testSubDir", Path: "target_test", Type: "lustre", Opts: []string{"ro", "noatime", "flock"}}},
+			expectedMountActions: []mount.FakeAction{{Action: "mount", Target: "target_test", Source: "1.1.1.1@tcp:/lustrefs/testSubDir", FSType: "lustre"}},
 		},
 		{
 			desc: "Error creating directory",
-			req: csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
-				VolumeId:          "vol_1",
-				TargetPath:        "./azurelustre.go",
-				StagingTargetPath: sourceTest,
-				VolumeContext:     map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs"},
-				Readonly:          true},
-			expectedErr: createDirError,
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1#lustrefs#1.1.1.1##true",
+				TargetPath:       "./azurelustre.go",
+				VolumeContext:    map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs"},
+				Readonly:         true,
+			},
+			expectedErr:          createDirError,
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
+		},
+		{
+			desc: "Internal mount path already mounted",
+			setup: func(d *Driver) {
+				err = makeDir(workingMountDir + "/false_is_likely#lustrefs#1.1.1.1#testSubDir#false")
+				assert.NoError(t, err)
+				err = d.mounter.Mount("1.1.1.1@tcp:/lustrefs/existing", workingMountDir+"/false_is_likely#lustrefs#1.1.1.1#testSubDir#false", "lustre", []string{"noatime", "flock"})
+				assert.NoError(t, err)
+			},
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock"}},
+				}},
+				VolumeId:      "false_is_likely#lustrefs#1.1.1.1#testSubDir#false",
+				TargetPath:    targetTest,
+				VolumeContext: map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": subDir, "retain-sub-dir": "false"},
+				Readonly:      false,
+			},
+			expectedErr:         nil,
+			expectedMountpoints: []mount.MountPoint{{Device: "1.1.1.1@tcp:/lustrefs/testSubDir", Path: "target_test", Type: "lustre", Opts: []string{"noatime", "flock"}}},
+			expectedMountActions: []mount.FakeAction{
+				{Action: "unmount", Target: workingMountDir + "/false_is_likely#lustrefs#1.1.1.1#testSubDir#false", Source: "", FSType: ""},
+				{Action: "mount", Target: workingMountDir + "/false_is_likely#lustrefs#1.1.1.1#testSubDir#false", Source: "1.1.1.1@tcp:/lustrefs", FSType: "lustre"},
+				{Action: "unmount", Target: workingMountDir + "/false_is_likely#lustrefs#1.1.1.1#testSubDir#false", Source: "", FSType: ""},
+				{Action: "mount", Target: "target_test", Source: "1.1.1.1@tcp:/lustrefs/testSubDir", FSType: "lustre"},
+			},
 		},
 		{
 			desc: "Success already mounted",
-			req: csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
-				VolumeId:          "vol_1",
-				TargetPath:        alreadyExistTarget,
-				StagingTargetPath: sourceTest,
-				VolumeContext:     map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs"},
-				Readonly:          true},
-			expectedErr: nil,
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1#lustrefs#1.1.1.1#testSubDir#true",
+				TargetPath:       alreadyExistTarget,
+				VolumeContext:    map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": subDir, "retain-sub-dir": "true"},
+				Readonly:         true,
+			},
+			expectedErr:          nil,
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
 		},
 		{
 			desc: "Error could not mount",
-			req: csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
-				VolumeId:          "vol_1",
-				TargetPath:        "error_mount_sens_mountflags",
-				StagingTargetPath: sourceTest,
-				VolumeContext:     map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs"},
-				Readonly:          true},
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1#lustrefs#1.1.1.1##true",
+				TargetPath:       "error_mount_sens_mountflags",
+				VolumeContext:    map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs"},
+				Readonly:         true,
+			},
 			expectedErr: status.Error(codes.Internal,
 				"Could not mount \"1.1.1.1@tcp:/lustrefs\" at \"error_mount_sens_mountflags\": fake MountSensitiveWithoutSystemdWithMountFlags: target error"),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
+		},
+		{
+			desc: "Error volume operation in progress",
+			setup: func(d *Driver) {
+				d.volumeLocks.TryAcquire("vol_1#lustrefs#1.1.1.1#testSubDir#false")
+			},
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1#lustrefs#1.1.1.1#testSubDir#false",
+				TargetPath:       targetTest,
+				VolumeContext:    map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": subDir, "retain-sub-dir": "false"},
+				Readonly:         false,
+			},
+			expectedErr:          status.Error(codes.Aborted, fmt.Sprintf(volumeOperationAlreadyExistsFmt, "vol_1#lustrefs#1.1.1.1#testSubDir#false")),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
+			cleanup: func(d *Driver) {
+				d.volumeLocks.Release("vol_1#lustrefs#1.1.1.1#testSubDir#false")
+			},
 		},
 	}
 
 	// Setup
-	_ = makeDir(sourceTest)
-	_ = makeDir(targetTest)
-	_ = makeDir(alreadyExistTarget)
 	d := NewFakeDriver()
-	fakeMounter := &fakeMounter{}
-	fakeExec := &testingexec.FakeExec{ExactOrder: true}
-	d.mounter = &mount.SafeFormatAndMount{
-		Interface: fakeMounter,
-		Exec:      fakeExec,
-	}
+
+	d.workingMountDir = workingMountDir
 
 	for _, test := range tests {
+		test := test // pin
+		fakeMounter := &fakeMounter{}
+		fakeExec := &testingexec.FakeExec{ExactOrder: true}
+		d.mounter = &mount.SafeFormatAndMount{
+			Interface: fakeMounter,
+			Exec:      fakeExec,
+		}
+		_ = makeDir(targetTest)
+		_ = makeDir(alreadyExistTarget)
+
 		if test.setup != nil {
 			test.setup(d)
 		}
-		_, err := d.NodePublishVolume(context.Background(), &test.req)
 
-		if !reflect.DeepEqual(err, test.expectedErr) {
-			t.Errorf("Desc: %s - Unexpected error: %v - Expected: %v", test.desc, err, test.expectedErr)
-		}
+		fakeMounter.ResetLog()
+
+		t.Run(test.desc, func(t *testing.T) {
+			_, err := d.NodePublishVolume(context.Background(), &test.req)
+			if !reflect.DeepEqual(err, test.expectedErr) {
+				t.Errorf("Desc: %v, Expected error: %v, Actual error: %v", test.desc, test.expectedErr, err)
+			}
+
+			mountPoints, _ := d.mounter.List()
+			assert.Equal(t, test.expectedMountpoints, mountPoints, "Desc: %s - Incorrect mount points: %v - Expected: %v", test.desc, mountPoints, test.expectedMountpoints)
+			mountActions := fakeMounter.GetLog()
+			assert.Equal(t, test.expectedMountActions, mountActions, "Desc: %s - Incorrect mount actions: %v - Expected: %v", test.desc, mountActions, test.expectedMountActions)
+
+			// Check that sub-dir has been created in the mount. This works because
+			// the contents in workingMountDir still exist after the test. The reason is
+			// os.Remove on workingMountDir fails because it is non-empty after unmount
+			// since it's not a real mounted Lustre
+			if subDirPath, ok := test.req.PublishContext["sub-dir"]; ok {
+				if test.expectedErr == nil {
+					internalMountDir := filepath.Join(d.workingMountDir, test.req.VolumeId)
+					subDirPath := filepath.Join(internalMountDir, subDirPath)
+					assert.DirExists(t, subDirPath, "Expected sub-dir %q to be created", subDirPath)
+					err = d.mounter.Unmount(internalMountDir)
+					assert.NoError(t, err)
+					err = os.RemoveAll(internalMountDir)
+					assert.NoError(t, err)
+				}
+			}
+		})
+
 		if test.cleanup != nil {
 			test.cleanup(d)
 		}
-	}
 
-	// Clean up
-	_ = d.mounter.Unmount(sourceTest)
-	err := d.mounter.Unmount(targetTest)
-	assert.NoError(t, err)
-	err = os.RemoveAll(alreadyExistTarget)
-	assert.NoError(t, err)
-	err = os.RemoveAll(sourceTest)
-	assert.NoError(t, err)
-	err = os.RemoveAll(targetTest)
-	assert.NoError(t, err)
+		err = d.mounter.Unmount(d.workingMountDir)
+		assert.NoError(t, err)
+		err = os.RemoveAll(d.workingMountDir)
+		assert.NoError(t, err)
+		err = d.mounter.Unmount(targetTest)
+		assert.NoError(t, err)
+		err = os.RemoveAll(alreadyExistTarget)
+		assert.NoError(t, err)
+		err = os.RemoveAll(targetTest)
+		assert.NoError(t, err)
+	}
 }
 
 func TestNodeUnpublishVolume(t *testing.T) {
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Errorf("failed to get current working directory")
+	}
+
+	workingMountDir := filepath.Join(workingDirectory, "workingMountDir")
+
 	tests := []struct {
-		desc        string
-		setup       func(*Driver)
-		req         csi.NodeUnpublishVolumeRequest
-		expectedErr error
-		cleanup     func(*Driver)
+		desc                 string
+		setup                func(*Driver)
+		req                  csi.NodeUnpublishVolumeRequest
+		expectedErr          error
+		expectExistingSubDir bool
+		expectedMountpoints  []mount.MountPoint
+		expectedMountActions []mount.FakeAction
+		cleanup              func(*Driver)
 	}{
 		{
-			desc:        "Volume ID missing",
-			req:         csi.NodeUnpublishVolumeRequest{TargetPath: targetTest},
-			expectedErr: status.Error(codes.InvalidArgument, "Volume ID missing in request"),
+			desc:                 "Volume ID missing",
+			req:                  csi.NodeUnpublishVolumeRequest{TargetPath: targetTest},
+			expectedErr:          status.Error(codes.InvalidArgument, "Volume ID missing in request"),
+			expectExistingSubDir: false,
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
 		},
 		{
-			desc:        "Target missing",
-			req:         csi.NodeUnpublishVolumeRequest{VolumeId: "vol_1"},
-			expectedErr: status.Error(codes.InvalidArgument, "Target path missing in request"),
+			desc:                 "Target missing",
+			req:                  csi.NodeUnpublishVolumeRequest{VolumeId: "vol_1"},
+			expectedErr:          status.Error(codes.InvalidArgument, "Target path missing in request"),
+			expectExistingSubDir: false,
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
 		},
 		{
-			desc:        "Valid request",
-			req:         csi.NodeUnpublishVolumeRequest{TargetPath: "./abc.go", VolumeId: "vol_1"},
-			expectedErr: nil,
+			desc:                 "Cannot find mount point",
+			req:                  csi.NodeUnpublishVolumeRequest{TargetPath: targetTest, VolumeId: "vol_1#lustrefs#1.1.1.1#testSubDir#false"},
+			expectedErr:          nil,
+			expectExistingSubDir: false,
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
+		},
+		{
+			desc: "sub-dir is not subpath of source, ignores sub-dir cleanup",
+			setup: func(d *Driver) {
+				err = makeDir(targetTest)
+				assert.NoError(t, err)
+				err = d.mounter.Mount("/otherPath", targetTest, "lustre", []string{"noatime", "flock"})
+				assert.NoError(t, err)
+			},
+			req:                  csi.NodeUnpublishVolumeRequest{TargetPath: targetTest, VolumeId: "vol_1#lustrefs#1.1.1.1#.#false"},
+			expectedErr:          nil,
+			expectExistingSubDir: false,
+			expectedMountpoints:  []mount.MountPoint{},
+			expectedMountActions: []mount.FakeAction{
+				{Action: "unmount", Target: "target_test", Source: "", FSType: ""},
+			},
+		},
+		{
+			desc: "sub-dir is not strict subpath, ignores sub-dir cleanup",
+			setup: func(d *Driver) {
+				err = makeDir(targetTest)
+				assert.NoError(t, err)
+				err = d.mounter.Mount("1.1.1.1@tcp:/lustrefs", targetTest, "lustre", []string{"noatime", "flock"})
+				assert.NoError(t, err)
+			},
+			req:                  csi.NodeUnpublishVolumeRequest{TargetPath: targetTest, VolumeId: "vol_1#lustrefs#1.1.1.1#.#false"},
+			expectedErr:          nil,
+			expectExistingSubDir: false,
+			expectedMountpoints:  []mount.MountPoint{},
+			expectedMountActions: []mount.FakeAction{
+				{Action: "unmount", Target: "target_test", Source: "", FSType: ""},
+			},
+		},
+		{
+			desc: "Valid request with old ID",
+			setup: func(d *Driver) {
+				volumeCap := csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER}
+				req := csi.NodePublishVolumeRequest{
+					VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock"}},
+					}},
+					VolumeId:      "vol_1#lustrefs#1.1.1.1",
+					TargetPath:    targetTest,
+					VolumeContext: map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs"},
+					Readonly:      false,
+				}
+				_, err := d.NodePublishVolume(context.Background(), &req)
+				assert.NoError(t, err)
+			},
+			req:                  csi.NodeUnpublishVolumeRequest{TargetPath: targetTest, VolumeId: "vol_1#lustrefs#1.1.1.1"},
+			expectedErr:          nil,
+			expectExistingSubDir: false,
+			expectedMountpoints:  []mount.MountPoint{},
+			expectedMountActions: []mount.FakeAction{
+				{Action: "unmount", Target: "target_test", Source: "", FSType: ""},
+			},
+		},
+		{
+			desc: "Error volume operation in progress",
+			setup: func(d *Driver) {
+				d.volumeLocks.TryAcquire("vol_1#lustrefs#1.1.1.1#testSubDir#false")
+			},
+			req:                  csi.NodeUnpublishVolumeRequest{TargetPath: targetTest, VolumeId: "vol_1#lustrefs#1.1.1.1#testSubDir#false"},
+			expectedErr:          status.Error(codes.Aborted, fmt.Sprintf(volumeOperationAlreadyExistsFmt, "vol_1#lustrefs#1.1.1.1#testSubDir#false")),
+			expectExistingSubDir: false,
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
+			cleanup: func(d *Driver) {
+				d.volumeLocks.Release("vol_1#lustrefs#1.1.1.1#testSubDir#false")
+			},
+		},
+		{
+			desc: "Attempt to clean sub-dir on read-only volume",
+			setup: func(d *Driver) {
+				internalMountDir := filepath.Join(d.workingMountDir, "vol_1#lustrefs#1.1.1.1#testSubDir#false")
+				subDirPath := filepath.Join(internalMountDir, subDir)
+				err = makeDir(subDirPath)
+				assert.NoError(t, err)
+				err = makeDir(targetTest)
+				assert.NoError(t, err)
+				err = d.mounter.Mount("1.1.1.1@tcp:/lustrefs/testSubDir", targetTest, "lustre", []string{"ro", "noatime", "flock"})
+				assert.NoError(t, err)
+			},
+			req:                  csi.NodeUnpublishVolumeRequest{TargetPath: targetTest, VolumeId: "vol_1#lustrefs#1.1.1.1#testSubDir#false"},
+			expectedErr:          nil,
+			expectExistingSubDir: true,
+			expectedMountpoints:  []mount.MountPoint{},
+			expectedMountActions: []mount.FakeAction{
+				{Action: "unmount", Target: "target_test", Source: "", FSType: ""},
+			},
+		},
+		{
+			desc: "Valid request without sub-dir cleanup",
+			setup: func(d *Driver) {
+				volumeCap := csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER}
+				req := csi.NodePublishVolumeRequest{
+					VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock"}},
+					}},
+					VolumeId:      "vol_1#lustrefs#1.1.1.1#testSubDir#true",
+					TargetPath:    targetTest,
+					VolumeContext: map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": subDir, "retain-sub-dir": "true"},
+					Readonly:      false,
+				}
+				_, err := d.NodePublishVolume(context.Background(), &req)
+				assert.NoError(t, err)
+			},
+			req:                  csi.NodeUnpublishVolumeRequest{TargetPath: targetTest, VolumeId: "vol_1#lustrefs#1.1.1.1#testSubDir#true"},
+			expectedErr:          nil,
+			expectExistingSubDir: true,
+			expectedMountpoints:  []mount.MountPoint{},
+			expectedMountActions: []mount.FakeAction{
+				{Action: "unmount", Target: "target_test", Source: "", FSType: ""},
+			},
+		},
+		{
+			desc: "Valid request with sub-dir cleanup",
+			setup: func(d *Driver) {
+				volumeCap := csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER}
+				req := csi.NodePublishVolumeRequest{
+					VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{MountFlags: []string{"noatime", "flock"}},
+					}},
+					VolumeId:      "vol_1#lustrefs#1.1.1.1#testSubDir#false",
+					TargetPath:    targetTest,
+					VolumeContext: map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": subDir, "retain-sub-dir": "false"},
+					Readonly:      false,
+				}
+				_, err := d.NodePublishVolume(context.Background(), &req)
+				assert.NoError(t, err)
+			},
+			req:                  csi.NodeUnpublishVolumeRequest{TargetPath: targetTest, VolumeId: "vol_1#lustrefs#1.1.1.1#testSubDir#false"},
+			expectedErr:          nil,
+			expectExistingSubDir: false,
+			expectedMountpoints:  []mount.MountPoint{},
+			expectedMountActions: []mount.FakeAction{
+				{Action: "unmount", Target: "target_test", Source: "", FSType: ""},
+				{Action: "mount", Target: workingMountDir + "/vol_1#lustrefs#1.1.1.1#testSubDir#false", Source: "1.1.1.1@tcp:/lustrefs", FSType: "lustre"},
+				{Action: "unmount", Target: workingMountDir + "/vol_1#lustrefs#1.1.1.1#testSubDir#false", Source: "", FSType: ""},
+			},
 		},
 	}
 
 	// Setup
-	_ = makeDir(sourceTest)
-	_ = makeDir(targetTest)
 	d := NewFakeDriver()
-
-	fakeMounter := &fakeMounter{}
-	fakeExec := &testingexec.FakeExec{ExactOrder: true}
-	d.mounter = &mount.SafeFormatAndMount{
-		Interface: fakeMounter,
-		Exec:      fakeExec,
-	}
+	d.workingMountDir = workingMountDir
 
 	for _, test := range tests {
+		test := test // pin
+		fakeMounter := &fakeMounter{}
+		fakeExec := &testingexec.FakeExec{ExactOrder: true}
+		d.mounter = &mount.SafeFormatAndMount{
+			Interface: fakeMounter,
+			Exec:      fakeExec,
+		}
+		_ = makeDir(targetTest)
+
 		if test.setup != nil {
 			test.setup(d)
 		}
-		_, err := d.NodeUnpublishVolume(context.Background(), &test.req)
 
-		if !reflect.DeepEqual(err, test.expectedErr) {
-			t.Errorf("Unexpected error: %v", err)
-		}
+		fakeMounter.ResetLog()
+
+		t.Run(test.desc, func(t *testing.T) {
+			_, err := d.NodeUnpublishVolume(context.Background(), &test.req)
+			if !reflect.DeepEqual(err, test.expectedErr) {
+				t.Errorf("Desc: %v, Expected error: %v, Actual error: %v", test.desc, test.expectedErr, err)
+			}
+			mountPoints, _ := d.mounter.List()
+			assert.Equal(t, test.expectedMountpoints, mountPoints, "Desc: %s - Incorrect mount points: %v - Expected: %v", test.desc, mountPoints, test.expectedMountpoints)
+			mountActions := fakeMounter.GetLog()
+			assert.Equal(t, test.expectedMountActions, mountActions, "Desc: %s - Incorrect mount actions: %v - Expected: %v", test.desc, mountActions, test.expectedMountActions)
+			internalMountDir := filepath.Join(d.workingMountDir, test.req.VolumeId)
+			if test.expectedErr == nil {
+				subDirPath := filepath.Join(internalMountDir, subDir)
+				if test.expectExistingSubDir {
+					assert.DirExists(t, subDirPath, "Expected sub-dir %q to be retained", subDirPath)
+				} else {
+					assert.NoDirExists(t, subDirPath, "Expected sub-dir %q to be deleted", internalMountDir)
+				}
+			}
+			err = d.mounter.Unmount(internalMountDir)
+			assert.NoError(t, err)
+			err = os.RemoveAll(internalMountDir)
+			assert.NoError(t, err)
+		})
 		if test.cleanup != nil {
 			test.cleanup(d)
 		}
-	}
 
-	//Clean up
-	err := d.mounter.Unmount(targetTest)
-	assert.NoError(t, err)
-	err = os.RemoveAll(sourceTest)
-	assert.NoError(t, err)
-	err = os.RemoveAll(targetTest)
-	assert.NoError(t, err)
+		err = d.mounter.Unmount(d.workingMountDir)
+		assert.NoError(t, err)
+		err = os.RemoveAll(d.workingMountDir)
+		assert.NoError(t, err)
+		err = d.mounter.Unmount(targetTest)
+		assert.NoError(t, err)
+		err = os.RemoveAll(targetTest)
+		assert.NoError(t, err)
+	}
 }
 
 func makeDir(pathname string) error {
@@ -373,11 +845,11 @@ func makeDir(pathname string) error {
 }
 
 func TestMakeDir(t *testing.T) {
-	//Successfully create directory
+	// Successfully create directory
 	err := makeDir(targetTest)
 	assert.NoError(t, err)
 
-	//Failed case
+	// Failed case
 	err = makeDir("./azurelustre.go")
 	var e *os.PathError
 	if !errors.As(err, &e) {
@@ -433,18 +905,460 @@ func TestNodeGetVolumeStats(t *testing.T) {
 	}
 
 	// Setup
-	_ = makeDir(fakePath)
 	d := NewFakeDriver()
 
 	for _, test := range tests {
-		_, err := d.NodeGetVolumeStats(context.Background(), &test.req)
-		//t.Errorf("[debug] error: %v\n metrics: %v", err, metrics)
-		if !reflect.DeepEqual(err, test.expectedErr) {
-			t.Errorf("desc: %v, expected error: %v, actual error: %v", test.desc, test.expectedErr, err)
-		}
+		_ = makeDir(fakePath)
+		test := test // pin
+		t.Run(test.desc, func(t *testing.T) {
+			_, err := d.NodeGetVolumeStats(context.Background(), &test.req)
+			if !reflect.DeepEqual(err, test.expectedErr) {
+				t.Errorf("Desc: %v, Expected error: %v, Actual error: %v", test.desc, test.expectedErr, err)
+			}
+		})
+
+		err := os.RemoveAll(fakePath)
+		assert.NoError(t, err)
+	}
+}
+
+func TestEnsureStrictSubpath(t *testing.T) {
+	cases := []struct {
+		desc           string
+		basePath       string
+		subPath        string
+		expectedErr    error
+		expectedResult bool
+	}{
+		{
+			desc:           "valid subpath",
+			basePath:       "/basePath",
+			subPath:        "subPath",
+			expectedErr:    nil,
+			expectedResult: true,
+		},
+		{
+			desc:           "valid subpath with leading slash",
+			basePath:       "/basePath",
+			subPath:        "/subPath",
+			expectedErr:    nil,
+			expectedResult: true,
+		},
+		{
+			desc:           "valid subpath, does not actually get to parent",
+			basePath:       "/basePath",
+			subPath:        "subPath/../otherSubPath",
+			expectedErr:    nil,
+			expectedResult: true,
+		},
+		{
+			desc:           "invalid subpath, attempts to go to parent",
+			basePath:       "/basePath",
+			subPath:        "../subPath",
+			expectedErr:    nil,
+			expectedResult: false,
+		},
+		{
+			desc:           "invalid subpath, same as parent",
+			basePath:       "/basePath",
+			subPath:        "./",
+			expectedErr:    nil,
+			expectedResult: false,
+		},
+		{
+			desc:           "invalid subpath, empty",
+			basePath:       "/basePath",
+			subPath:        "",
+			expectedErr:    nil,
+			expectedResult: false,
+		},
+	}
+	for _, test := range cases {
+		test := test // pin
+		t.Run(test.desc, func(t *testing.T) {
+			actualResult, err := ensureStrictSubpath(test.basePath, test.subPath)
+
+			if !reflect.DeepEqual(err, test.expectedErr) {
+				t.Errorf("Desc: %v, Expected error: %v, Actual error: %v", test.desc, test.expectedErr, err)
+			}
+			assert.Equal(t, test.expectedResult, actualResult, "Desc: %s - Incorrect lustre volume: %v - Expected: %v", test.desc, actualResult, test.expectedResult)
+		})
+	}
+}
+
+func TestGetLustreVolFromID(t *testing.T) {
+	cases := []struct {
+		desc                 string
+		volumeID             string
+		expectedLustreVolume *lustreVolume
+		expectedErr          error
+	}{
+		{
+			desc:     "correct volume id",
+			volumeID: "vol_1#lustrefs#1.1.1.1#testSubDir#false",
+			expectedLustreVolume: &lustreVolume{
+				id:              "vol_1#lustrefs#1.1.1.1#testSubDir#false",
+				name:            "vol_1",
+				azureLustreName: "lustrefs",
+				mgsIPAddress:    "1.1.1.1",
+				subDir:          "testSubDir",
+				retainSubDir:    false,
+			},
+		},
+		{
+			desc:     "correct volume id with /",
+			volumeID: "vol_1#lustrefs/#1.1.1.1#/testSubDir/#true",
+			expectedLustreVolume: &lustreVolume{
+				id:              "vol_1#lustrefs/#1.1.1.1#/testSubDir/#true",
+				name:            "vol_1",
+				azureLustreName: "lustrefs",
+				mgsIPAddress:    "1.1.1.1",
+				subDir:          "testSubDir",
+				retainSubDir:    true,
+			},
+		},
+		{
+			desc:     "correct volume id with empty sub-dir",
+			volumeID: "vol_1#lustrefs/#1.1.1.1##",
+			expectedLustreVolume: &lustreVolume{
+				id:              "vol_1#lustrefs/#1.1.1.1##",
+				name:            "vol_1",
+				azureLustreName: "lustrefs",
+				mgsIPAddress:    "1.1.1.1",
+				subDir:          "",
+				retainSubDir:    true,
+			},
+		},
+		{
+			desc:     "correct volume id with multiple sub-dir levels",
+			volumeID: "vol_1#lustrefs#1.1.1.1#testSubDir/nestedSubDir#false",
+			expectedLustreVolume: &lustreVolume{
+				id:              "vol_1#lustrefs#1.1.1.1#testSubDir/nestedSubDir#false",
+				name:            "vol_1",
+				azureLustreName: "lustrefs",
+				mgsIPAddress:    "1.1.1.1",
+				subDir:          "testSubDir/nestedSubDir",
+				retainSubDir:    false,
+			},
+		},
+		{
+			desc:                 "incorrect volume id",
+			volumeID:             "vol_1",
+			expectedLustreVolume: nil,
+			expectedErr:          errors.New("could not split volume id \"vol_1\" into lustre name and ip address"),
+		},
+		{
+			desc:        "incorrect retain-sub-dir",
+			volumeID:    "vol_1#lustrefs#1.1.1.1#testSubDir#f",
+			expectedErr: errors.New("could not parse retain-sub-dir value \"f\" into boolean"),
+		},
+	}
+	for _, test := range cases {
+		test := test // pin
+		t.Run(test.desc, func(t *testing.T) {
+			lustreVolume, err := getLustreVolFromID(test.volumeID)
+
+			if !reflect.DeepEqual(err, test.expectedErr) {
+				t.Errorf("Desc: %v, Expected error: %v, Actual error: %v", test.desc, test.expectedErr, err)
+			}
+			assert.Equal(t, test.expectedLustreVolume, lustreVolume, "Desc: %s - Incorrect lustre volume: %v - Expected: %v", test.desc, lustreVolume, test.expectedLustreVolume)
+		})
+	}
+}
+
+func TestGetInternalVolumePath(t *testing.T) {
+	cases := []struct {
+		desc            string
+		workingMountDir string
+		vol             *lustreVolume
+		subDirPath      string
+		result          string
+		expectedErr     error
+	}{
+		{
+			desc:            "nil volume",
+			workingMountDir: "/tmp",
+			vol:             nil,
+			subDirPath:      "",
+			result:          "",
+			expectedErr:     status.Error(codes.Internal, "cannot get internal mount path for nil or empty volume"),
+		},
+		{
+			desc:            "empty volume",
+			workingMountDir: "/tmp",
+			vol: &lustreVolume{
+				id:              "",
+				name:            "",
+				azureLustreName: "",
+				mgsIPAddress:    "",
+				subDir:          "",
+				retainSubDir:    false,
+			},
+			subDirPath:  "",
+			result:      "",
+			expectedErr: status.Error(codes.Internal, "cannot get internal mount path for nil or empty volume"),
+		},
+		{
+			desc:            "valid volume",
+			workingMountDir: "/tmp",
+			vol: &lustreVolume{
+				id:              "vol_1#lustrefs#1.1.1.1#testSubDir#false",
+				name:            "vol_1",
+				azureLustreName: "lustrefs",
+				mgsIPAddress:    "1.1.1.1",
+				subDir:          "testSubDir",
+				retainSubDir:    false,
+			},
+			subDirPath:  "testSubDir",
+			result:      filepath.Join("/tmp", "vol_1#lustrefs#1.1.1.1#testSubDir#false/testSubDir"),
+			expectedErr: nil,
+		},
+		{
+			desc:            "valid volume with multiple sub-dir levels",
+			workingMountDir: "/tmp",
+			vol: &lustreVolume{
+				id:              "vol_1#lustrefs#1.1.1.1#testSubDir/nestedSubDir#false",
+				name:            "vol_1",
+				azureLustreName: "lustrefs",
+				mgsIPAddress:    "1.1.1.1",
+				subDir:          "testSubDir/nestedSubDir",
+				retainSubDir:    false,
+			},
+			subDirPath:  "testSubDir/nestedSubDir",
+			result:      filepath.Join("/tmp", "vol_1#lustrefs#1.1.1.1#testSubDir/nestedSubDir#false/testSubDir/nestedSubDir"),
+			expectedErr: nil,
+		},
+		{
+			desc:            "invalid sub-dir that would go to parent dir",
+			workingMountDir: "/tmp",
+			vol: &lustreVolume{
+				id:              "vol_1#lustrefs#1.1.1.1#../testSubDir#false",
+				name:            "vol_1",
+				azureLustreName: "lustrefs",
+				mgsIPAddress:    "1.1.1.1",
+				subDir:          "../testSubDir",
+				retainSubDir:    false,
+			},
+			subDirPath:  "../testSubDir",
+			result:      "",
+			expectedErr: status.Error(codes.InvalidArgument, "sub-dir \"../testSubDir\" must be strict subpath"),
+		},
 	}
 
-	// Clean up
-	err := os.RemoveAll(fakePath)
-	assert.NoError(t, err)
+	for _, test := range cases {
+		test := test // pin
+		t.Run(test.desc, func(t *testing.T) {
+			path, err := getInternalVolumePath(test.workingMountDir, test.vol, test.subDirPath)
+			if !reflect.DeepEqual(err, test.expectedErr) {
+				t.Errorf("Desc: %v, Expected error: %v, Actual error: %v", test.desc, test.expectedErr, err)
+			}
+			assert.Equal(t, test.result, path)
+		})
+	}
+}
+
+func TestGetInternalMountPath(t *testing.T) {
+	cases := []struct {
+		desc            string
+		workingMountDir string
+		vol             *lustreVolume
+		result          string
+		expectedErr     error
+	}{
+		{
+			desc:            "nil volume",
+			workingMountDir: "/tmp",
+			vol:             nil,
+			result:          "",
+			expectedErr:     status.Error(codes.Internal, "cannot get internal mount path for nil or empty volume"),
+		},
+		{
+			desc:            "empty volume",
+			workingMountDir: "/tmp",
+			vol: &lustreVolume{
+				id:              "",
+				name:            "",
+				azureLustreName: "",
+				mgsIPAddress:    "",
+				subDir:          "",
+				retainSubDir:    false,
+			},
+			result:      "",
+			expectedErr: status.Error(codes.Internal, "cannot get internal mount path for nil or empty volume"),
+		},
+		{
+			desc:            "valid volume",
+			workingMountDir: "/tmp",
+			vol: &lustreVolume{
+				id:              "vol_1#lustrefs#1.1.1.1#testSubDir#false",
+				name:            "vol_1",
+				azureLustreName: "lustrefs",
+				mgsIPAddress:    "1.1.1.1",
+				subDir:          "testSubDir",
+				retainSubDir:    false,
+			},
+			result:      filepath.Join("/tmp", "vol_1#lustrefs#1.1.1.1#testSubDir#false"),
+			expectedErr: nil,
+		},
+		{
+			desc:            "invalid id that would go to parent dir",
+			workingMountDir: "/tmp",
+			vol: &lustreVolume{
+				id:              "../../../vol_1#lustrefs#1.1.1.1#testSubDir#false",
+				name:            "../../../vol_1",
+				azureLustreName: "lustrefs",
+				mgsIPAddress:    "1.1.1.1",
+				subDir:          "testSubDir",
+				retainSubDir:    false,
+			},
+			result:      "",
+			expectedErr: status.Error(codes.InvalidArgument, "volume name or id \"../../../vol_1#lustrefs#1.1.1.1#testSubDir#false\" must be interpretable as a strict subpath"),
+		},
+	}
+
+	for _, test := range cases {
+		test := test // pin
+		t.Run(test.desc, func(t *testing.T) {
+			path, err := getInternalMountPath(test.workingMountDir, test.vol)
+			if !reflect.DeepEqual(err, test.expectedErr) {
+				t.Errorf("Desc: %v, Expected error: %v, Actual error: %v", test.desc, test.expectedErr, err)
+			}
+			assert.Equal(t, test.result, path)
+		})
+	}
+}
+
+func TestNewLustreVolume(t *testing.T) {
+	cases := []struct {
+		desc                 string
+		id                   string
+		params               map[string]string
+		expectedLustreVolume *lustreVolume
+		expectedErr          error
+	}{
+		{
+			desc: "valid context, no sub-dir",
+			id:   "vol_1#lustrefs#1.1.1.1##true",
+			params: map[string]string{
+				"mgs-ip-address": "1.1.1.1",
+				"fs-name":        "lustrefs",
+			},
+			expectedLustreVolume: &lustreVolume{
+				id:              "vol_1#lustrefs#1.1.1.1##true",
+				name:            "vol_1",
+				azureLustreName: "lustrefs",
+				mgsIPAddress:    "1.1.1.1",
+				subDir:          "",
+				retainSubDir:    true,
+			},
+		},
+		{
+			desc: "valid context with sub-dir",
+			id:   "vol_1#lustrefs#1.1.1.1#testSubDir#false",
+			params: map[string]string{
+				"mgs-ip-address": "1.1.1.1",
+				"fs-name":        "lustrefs",
+				"sub-dir":        "testSubDir",
+				"retain-sub-dir": "false",
+			},
+			expectedLustreVolume: &lustreVolume{
+				id:              "vol_1#lustrefs#1.1.1.1#testSubDir#false",
+				name:            "vol_1",
+				azureLustreName: "lustrefs",
+				mgsIPAddress:    "1.1.1.1",
+				subDir:          "testSubDir",
+				retainSubDir:    false,
+			},
+		},
+		{
+			desc: "invalid parameter is ignored",
+			id:   "vol_1#lustrefs#1.1.1.1##true",
+			params: map[string]string{
+				"mgs-ip-address":    "1.1.1.1",
+				"fs-name":           "lustrefs",
+				"invalid-parameter": "value",
+			},
+			expectedLustreVolume: &lustreVolume{
+				id:              "vol_1#lustrefs#1.1.1.1##true",
+				name:            "vol_1",
+				azureLustreName: "lustrefs",
+				mgsIPAddress:    "1.1.1.1",
+				subDir:          "",
+				retainSubDir:    true,
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "incorrect volume id is ignored for context",
+			id:   "vol_1#otherfs#2.2.2.2#otherSubDir#false",
+			params: map[string]string{
+				"mgs-ip-address": "1.1.1.1",
+				"fs-name":        "lustrefs",
+				"sub-dir":        "testSubDir",
+				"retain-sub-dir": "true",
+			},
+			expectedLustreVolume: &lustreVolume{
+				id:              "vol_1#lustrefs#1.1.1.1#testSubDir#true",
+				name:            "vol_1",
+				azureLustreName: "lustrefs",
+				mgsIPAddress:    "1.1.1.1",
+				subDir:          "testSubDir",
+				retainSubDir:    true,
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "sub-dir cannot be empty",
+			id:   "vol_1#lustrefs#1.1.1.1##false",
+			params: map[string]string{
+				"mgs-ip-address": "1.1.1.1",
+				"fs-name":        "lustrefs",
+				"sub-dir":        "",
+				"retain-sub-dir": "false",
+			},
+			expectedErr: status.Error(codes.InvalidArgument, "Context sub-dir must not be empty or root if provided"),
+		},
+		{
+			desc: "sub-dir cannot be root",
+			id:   "vol_1#lustrefs#1.1.1.1#/#false",
+			params: map[string]string{
+				"mgs-ip-address": "1.1.1.1",
+				"fs-name":        "lustrefs",
+				"sub-dir":        "/",
+				"retain-sub-dir": "false",
+			},
+			expectedErr: status.Error(codes.InvalidArgument, "Context sub-dir must not be empty or root if provided"),
+		},
+		{
+			desc: "must have retain-sub-dir with sub-dir",
+			id:   "vol_1#lustrefs#1.1.1.1#testSubDir#",
+			params: map[string]string{
+				"mgs-ip-address": "1.1.1.1",
+				"fs-name":        "lustrefs",
+				"sub-dir":        "testSubDir",
+			},
+			expectedErr: status.Error(codes.InvalidArgument, "Context retain-sub-dir must be provided when sub-dir is provided"),
+		},
+		{
+			desc: "sub-dir cannot be root",
+			id:   "vol_1#lustrefs#1.1.1.1##false",
+			params: map[string]string{
+				"mgs-ip-address": "1.1.1.1",
+				"fs-name":        "lustrefs",
+				"retain-sub-dir": "false",
+			},
+			expectedErr: status.Error(codes.InvalidArgument, "Context sub-dir must be provided when retain-sub-dir is provided"),
+		},
+	}
+
+	for _, test := range cases {
+		test := test // pin
+		t.Run(test.desc, func(t *testing.T) {
+			vol, err := newLustreVolume(test.id, test.params)
+			if !reflect.DeepEqual(err, test.expectedErr) {
+				t.Errorf("[test: %s] Unexpected error: %v, expected error: %v", test.desc, err, test.expectedErr)
+			}
+			assert.Equal(t, test.expectedLustreVolume, vol, "Desc: %s - Incorrect lustre volume: %v - Expected: %v", test.desc, vol, test.expectedLustreVolume)
+		})
+	}
 }

--- a/pkg/azurelustre/version_test.go
+++ b/pkg/azurelustre/version_test.go
@@ -42,7 +42,6 @@ func TestGetVersion(t *testing.T) {
 	if !reflect.DeepEqual(version, expected) {
 		t.Errorf("Unexpected error. \n Expected: %v \n Found: %v", expected, version)
 	}
-
 }
 
 func TestGetVersionYAML(t *testing.T) {

--- a/pkg/azurelustreplugin/main.go
+++ b/pkg/azurelustreplugin/main.go
@@ -32,6 +32,7 @@ var (
 	version                    = flag.Bool("version", false, "Print the version and exit.")
 	driverName                 = flag.String("drivername", azurelustre.DefaultDriverName, "name of the driver")
 	enableAzureLustreMockMount = flag.Bool("enable-azurelustre-mock-mount", false, "Whether enable mock mount(only for testing)")
+	workingMountDir            = flag.String("working-mount-dir", "/tmp", "working directory for provisioner to mount lustre filesystems temporarily")
 )
 
 func main() {
@@ -56,6 +57,7 @@ func handle() {
 		NodeID:                     *nodeID,
 		DriverName:                 *driverName,
 		EnableAzureLustreMockMount: *enableAzureLustreMockMount,
+		WorkingMountDir:            *workingMountDir,
 	}
 	driver := azurelustre.NewDriver(&driverOptions)
 	if driver == nil {

--- a/pkg/csi-common/driver.go
+++ b/pkg/csi-common/driver.go
@@ -48,7 +48,7 @@ func NewCSIDriver(name string, v string, nodeID string) *CSIDriver {
 	// TODO version format and validation
 	if len(v) == 0 {
 		klog.Errorf("Version argument missing, now skip it")
-		//return nil
+		// return nil
 	}
 
 	driver := CSIDriver{

--- a/pkg/csi-common/driver_test.go
+++ b/pkg/csi-common/driver_test.go
@@ -30,9 +30,7 @@ const (
 	fakeNodeID     = "fakeNodeID"
 )
 
-var (
-	vendorVersion = "0.3.0"
-)
+var vendorVersion = "0.3.0"
 
 func TestNewCSIDriver(t *testing.T) {
 	name := ""
@@ -51,7 +49,6 @@ func TestNewCSIDriver(t *testing.T) {
 }
 
 func NewFakeDriver() *CSIDriver {
-
 	driver := NewCSIDriver(fakeDriverName, vendorVersion, fakeNodeID)
 
 	return driver
@@ -123,5 +120,4 @@ func TestValidateControllerServiceRequest(t *testing.T) {
 	// Test controller service get capacity is supported
 	err = d.ValidateControllerServiceRequest(csi.ControllerServiceCapability_RPC_GET_CAPACITY)
 	assert.NoError(t, err)
-
 }

--- a/pkg/csi-common/server_test.go
+++ b/pkg/csi-common/server_test.go
@@ -38,7 +38,7 @@ func TestServe(_ *testing.T) {
 	s := nonBlockingGRPCServer{}
 	s.server = grpc.NewServer()
 	s.wg = sync.WaitGroup{}
-	//need to add one here as the actual also requires one.
+	// need to add one here as the actual also requires one.
 	s.wg.Add(1)
 	s.serve("tcp://127.0.0.1:0", nil, nil, nil, true)
 }

--- a/pkg/csi-common/utils_test.go
+++ b/pkg/csi-common/utils_test.go
@@ -30,8 +30,7 @@ import (
 )
 
 func TestParseEndpoint(t *testing.T) {
-
-	//Valid unix domain socket endpoint
+	// Valid unix domain socket endpoint
 	sockType, addr, err := ParseEndpoint("unix://fake.sock")
 	assert.NoError(t, err)
 	assert.Equal(t, "unix", sockType)
@@ -42,25 +41,25 @@ func TestParseEndpoint(t *testing.T) {
 	assert.Equal(t, "unix", sockType)
 	assert.Equal(t, "/fakedir/fakedir/fake.sock", addr)
 
-	//Valid unix domain socket with uppercase
+	// Valid unix domain socket with uppercase
 	sockType, addr, err = ParseEndpoint("UNIX://fake.sock")
 	assert.NoError(t, err)
 	assert.Equal(t, "UNIX", sockType)
 	assert.Equal(t, "fake.sock", addr)
 
-	//Valid TCP endpoint with ip
+	// Valid TCP endpoint with ip
 	sockType, addr, err = ParseEndpoint("tcp://127.0.0.1:80")
 	assert.NoError(t, err)
 	assert.Equal(t, "tcp", sockType)
 	assert.Equal(t, "127.0.0.1:80", addr)
 
-	//Valid TCP endpoint with uppercase
+	// Valid TCP endpoint with uppercase
 	sockType, addr, err = ParseEndpoint("TCP://127.0.0.1:80")
 	assert.NoError(t, err)
 	assert.Equal(t, "TCP", sockType)
 	assert.Equal(t, "127.0.0.1:80", addr)
 
-	//Valid TCP endpoint with hostname
+	// Valid TCP endpoint with hostname
 	sockType, addr, err = ParseEndpoint("tcp://fakehost:80")
 	assert.NoError(t, err)
 	assert.Equal(t, "tcp", sockType)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -111,6 +111,7 @@ func TestUnlockEntryNotExists(t *testing.T) {
 	testLockMap.UnlockEntry("entry2")
 	testLockMap.UnlockEntry("entry1")
 }
+
 func TestBytesToGiB(t *testing.T) {
 	var sizeInBytes int64 = 5 * GiB
 
@@ -157,7 +158,7 @@ func TestGetMountOptions(t *testing.T) {
 }
 
 func TestMakeDir(t *testing.T) {
-	//Successfully create directory
+	// Successfully create directory
 	targetTest := "./target_test"
 	err := MakeDir(targetTest)
 	assert.NoError(t, err)

--- a/test/external-e2e/e2etest_storageclass.yaml.template
+++ b/test/external-e2e/e2etest_storageclass.yaml.template
@@ -7,6 +7,8 @@ provisioner: azurelustre.csi.azure.com
 parameters:
   mgs-ip-address: "{lustre_mgs_ip}"
   fs-name: "{lustre_fs_name}"
+  sub-dir: "longhaul/${pvc.metadata.name}"
+  retain-sub-dir: "true"
 mountOptions:
   - noatime
   - flock

--- a/test/long-haul/cleanup/cleanupjob.yaml
+++ b/test/long-haul/cleanup/cleanupjob.yaml
@@ -7,6 +7,8 @@ provisioner: azurelustre.csi.azure.com
 parameters:
   mgs-ip-address: "{lustre_fs_ip}"
   fs-name: "{lustre_fs_name}"
+  sub-dir: "longhaul"
+  retain-sub-dir: "false"
 
 ---
 kind: PersistentVolumeClaim

--- a/test/long-haul/sample-workload/deployment_write_print_file.yaml
+++ b/test/long-haul/sample-workload/deployment_write_print_file.yaml
@@ -7,6 +7,8 @@ provisioner: azurelustre.csi.azure.com
 parameters:
   mgs-ip-address: "{lustre_fs_ip}"
   fs-name: "{lustre_fs_name}"
+  sub-dir: "longhaul/${pvc.metadata.name}"
+  retain-sub-dir: "true"
 
 ---
 kind: PersistentVolumeClaim


### PR DESCRIPTION
This commit adds the ability for pods to bind to a Lustre volume in a specified subdirectory. The pod that binds the volume in this way can only see that path and the paths under it. It has no access or visibility to other paths above it in the Lustre filesystem.

This has been implemented similarly to other CSI drivers to meet user expectations, but has the added benefit of allowing the user to leverage metadata from both the pvc/pv metadata and the pod's metadata as well.

Numerous checks have been put in place to ensure that data outside of the requested subdirectory is not deleted and that read only volumes are handled reasonably.

The long-haul tests have had compatible subdirectory values set to exercise this functionality while still maintaining its expectations as to data persistence, etc.

This is largely based on the implementations in the nfs and smb drivers, but it operates on a per-pod basis.

Design document (for MSFT employees) here: https://dev.azure.com/msazure/One/_git/Avere-laaso-doc/pullrequest/9149798

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
