### PR TITLE
Correct per-publish/unpublish lock

### DIFF
--- a/test/scale/run_test.py
+++ b/test/scale/run_test.py
@@ -129,6 +129,7 @@ class PerfScaleTest:
             "mgs_ip_address": args.mgs_ip_address,
             "fs_name": args.fs_name,
             "scale": 0,
+            "pod.metadata.name": "${pod.metadata.name}",
         }
         self._scales = args.scales
         logger.info(f"test scales {self._scales}")

--- a/test/scale/static_workload.yml.template
+++ b/test/scale/static_workload.yml.template
@@ -13,7 +13,9 @@ spec:
     volumeAttributes:
       fs-name: ${fs_name}
       mgs-ip-address: ${mgs_ip_address}
-    volumeHandle: scale-pv-lustre-01
+      sub-dir: "longhaul/${pod.metadata.name}"
+      retain-sub-dir: "false"
+    volumeHandle: scale-pv-lustre#${fs_name}#${mgs_ip_address}#longhaul/${pod.metadata.name}#false
   persistentVolumeReclaimPolicy: Retain
 
 ---


### PR DESCRIPTION
Locking at the volume level was necessary for the original proof of concept that used stage/unstage steps with a global path. However, with the lock being used per-publish/unpublish step, it was causing unnecessary slowdowns when many pods were created or deleted for a given volume. This commit changes the behavior to lock only for a specific pod's directory, which will avoid this delay across individual pods for a single volume.
    
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug 

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
