### PR TITLE
Skip subdirectory creation for invalid volume ID

### DIFF
--- a/docs/examples/pv_subdir.yaml
+++ b/docs/examples/pv_subdir.yaml
@@ -27,6 +27,11 @@ spec:
       # This parameter is required if "sub-dir" is provided
       retain-sub-dir: "false"
     # Make sure this VolumeID is unique in the cluster
+    # volumeHandle format: {volume-name}#{fs-name}#{mgs-ip-address}#{sub-dir}#{retain-sub-dir}
+    # Example: vol_1#lustrefs#0.0.0.0#example_sub_dir#true
+    # If the value does not match this format, the driver will not attempt to create
+    #   the configured subdirectory. Further, if retain-sub-dir is 'false' in that
+    #   case, any attempt to mount this volume will fail.
     volumeHandle: ${UNIQUE_IDENTIFIER_VOLUME_ID}
   # "Delete" is not supported in static provisioning PV
   mountOptions:


### PR DESCRIPTION
The only reasonable way that the unpublish command can determine whether to keep or delete the subdirectory, if given, is to bake this information into the volume ID, as the original volume context is not passed to volume unpublish calls. For dynamically created volumes, this is always consistent. However, if the end user defines their own volumes, but does not follow the expected volume handle / volume ID form, that information is not available. In this instance, if the user sets the retain-sub-dir value on a manually created volume to 'false', we will error out and refuse to create the volume. If they request that the subdirectory be retained, we will treat the volume as we do a read-only volume, where we will attempt to mount the given subdirectory, but will not do any logic associated with creating or deleting that subdirectory. As with a read-only volume, if that subdirectory does not exist on the cluster, the mount will fail with a reasonable error.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->



**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:
This PR is based on https://github.com/kubernetes-sigs/azurelustre-csi-driver/pull/155 and will be in draft until that is merged.

**Release note**:
```
none
```
