### PR TITLE
Remove retain-sub-dir option

### DIFF
--- a/docs/examples/pv_subdir.yaml
+++ b/docs/examples/pv_subdir.yaml
@@ -23,15 +23,7 @@ spec:
       mgs-ip-address: ${EXISTING_LUSTRE_IP_ADDRESS}
       # The subdirectory to create and mount per pod (cannot use pvc / pv metadata in static volumes)
       sub-dir: "${pod.metadata.namespace}_${pod.metadata.name}"
-      # Whether the created subdirectory should be retained or deleted at pod exit
-      # This parameter is required if "sub-dir" is provided
-      retain-sub-dir: "false"
     # Make sure this VolumeID is unique in the cluster
-    # volumeHandle format: {volume-name}#{fs-name}#{mgs-ip-address}#{sub-dir}#{retain-sub-dir}
-    # Example: vol_1#lustrefs#0.0.0.0#example_sub_dir#true
-    # If the value does not match this format, the driver will not attempt to create
-    #   the configured subdirectory. Further, if retain-sub-dir is 'false' in that
-    #   case, any attempt to mount this volume will fail.
     volumeHandle: ${UNIQUE_IDENTIFIER_VOLUME_ID}
   # "Delete" is not supported in static provisioning PV
   mountOptions:

--- a/docs/examples/storageclass_existing_lustre_subdir.yaml
+++ b/docs/examples/storageclass_existing_lustre_subdir.yaml
@@ -14,9 +14,6 @@ parameters:
   mgs-ip-address: ${EXISTING_LUSTRE_IP_ADDRESS}
   # The subdirectory to create and mount per pod
   sub-dir: "${pvc.metadata.name}_${pod.metadata.name}"
-  # Whether the created subdirectory should be retained or deleted at pod exit
-  # This parameter is required if "sub-dir" is provided
-  retain-sub-dir: "false"
 provisioner: azurelustre.csi.azure.com
 reclaimPolicy: Delete
 volumeBindingMode: Immediate

--- a/pkg/azurelustre/azurelustre.go
+++ b/pkg/azurelustre/azurelustre.go
@@ -35,7 +35,7 @@ const (
 	DefaultDriverName        = "azurelustre.csi.azure.com"
 	azureLustreCSIDriverName = "azurelustre_csi_driver"
 	separator                = "#"
-	volumeIDTemplate         = "%s#%s#%s#%s#%t"
+	volumeIDTemplate         = "%s#%s#%s#%s"
 
 	podNameKey            = "csi.storage.k8s.io/pod.name"
 	podNamespaceKey       = "csi.storage.k8s.io/pod.namespace"

--- a/pkg/azurelustre/controllerserver.go
+++ b/pkg/azurelustre/controllerserver.go
@@ -35,7 +35,6 @@ const (
 	VolumeContextMGSIPAddress = "mgs-ip-address"
 	VolumeContextFSName       = "fs-name"
 	VolumeContextSubDir       = "sub-dir"
-	VolumeContextRetainSubDir = "retain-sub-dir"
 	defaultSize               = 4 * 1024 * 1024 * 1024 * 1024 // 4TiB
 	laaSOBlockSize            = 4 * 1024 * 1024 * 1024 * 1024 // 4TiB
 )
@@ -260,9 +259,6 @@ func createVolumeIDFromParams(volName string, params map[string]string) (string,
 
 	var errorParameters []string
 
-	// Shouldn't attempt to delete anything unless sub-dir is actually specified
-	retainSubDir := true
-
 	// validate parameters (case-insensitive).
 	for k, v := range params {
 		switch strings.ToLower(k) {
@@ -278,30 +274,6 @@ func createVolumeIDFromParams(volName string, params map[string]string) (string,
 				return "", status.Error(
 					codes.InvalidArgument,
 					"CreateVolume Parameter sub-dir must not be empty if provided",
-				)
-			}
-
-			if _, ok := params[VolumeContextRetainSubDir]; !ok {
-				return "", status.Error(
-					codes.InvalidArgument,
-					"CreateVolume Parameter retain-sub-dir must be provided when sub-dir is provided",
-				)
-			}
-		case VolumeContextRetainSubDir:
-			retainSubDirString := strings.ToLower(v)
-			if retainSubDirString != "true" && retainSubDirString != "false" {
-				return "", status.Error(
-					codes.InvalidArgument,
-					"CreateVolume Parameter retain-sub-dir value must be either true or false",
-				)
-			}
-
-			retainSubDir = retainSubDirString == "true"
-
-			if _, ok := params[VolumeContextSubDir]; !ok {
-				return "", status.Error(
-					codes.InvalidArgument,
-					"CreateVolume Parameter sub-dir must be provided when retain-sub-dir is provided",
 				)
 			}
 		// These will be used by the node methods
@@ -340,7 +312,7 @@ func createVolumeIDFromParams(volName string, params map[string]string) (string,
 		)
 	}
 
-	volumeID := fmt.Sprintf(volumeIDTemplate, volName, azureLustreName, mgsIPAddress, subDir, retainSubDir)
+	volumeID := fmt.Sprintf(volumeIDTemplate, volName, azureLustreName, mgsIPAddress, subDir)
 
 	return volumeID, nil
 }

--- a/pkg/azurelustre/controllerserver_test.go
+++ b/pkg/azurelustre/controllerserver_test.go
@@ -74,7 +74,6 @@ func buildCreateVolumeRequest() *csi.CreateVolumeRequest {
 			"fs-name":        "tfs",
 			"mgs-ip-address": "127.0.0.1",
 			"sub-dir":        "testSubDir",
-			"retain-sub-dir": "false",
 		},
 	}
 	return req
@@ -217,32 +216,6 @@ func TestCreateVolume_Err_ParametersEmptySubDir(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, grpcStatus.Code())
 	assert.ErrorContains(t, err, "sub-dir")
-}
-
-func TestCreateVolume_Err_ParametersSubDirWithoutRetainSubDir(t *testing.T) {
-	d := NewFakeDriver()
-	req := buildCreateVolumeRequest()
-	delete(req.Parameters, VolumeContextRetainSubDir)
-	_, err := d.CreateVolume(context.Background(), req)
-	assert.Error(t, err)
-	grpcStatus, ok := status.FromError(err)
-	assert.True(t, ok)
-	assert.Equal(t, codes.InvalidArgument, grpcStatus.Code())
-	assert.ErrorContains(t, err, " sub-dir ")
-	assert.ErrorContains(t, err, "retain-sub-dir")
-}
-
-func TestCreateVolume_Err_ParametersRetainSubDirWithoutSubDir(t *testing.T) {
-	d := NewFakeDriver()
-	req := buildCreateVolumeRequest()
-	delete(req.Parameters, VolumeContextSubDir)
-	_, err := d.CreateVolume(context.Background(), req)
-	assert.Error(t, err)
-	grpcStatus, ok := status.FromError(err)
-	assert.True(t, ok)
-	assert.Equal(t, codes.InvalidArgument, grpcStatus.Code())
-	assert.ErrorContains(t, err, " sub-dir ")
-	assert.ErrorContains(t, err, "retain-sub-dir")
 }
 
 func TestCreateVolume_Err_UnknownParameters(t *testing.T) {
@@ -412,7 +385,7 @@ func TestDeleteVolume_Success(t *testing.T) {
 	d := NewFakeDriver()
 	req := &csi.DeleteVolumeRequest{
 		VolumeId: fmt.Sprintf(volumeIDTemplate,
-			"testVolume", "testFs", "127.0.0.1", "testSubDir", false),
+			"testVolume", "testFs", "127.0.0.1", "testSubDir"),
 	}
 	_, err := d.DeleteVolume(context.Background(), req)
 	assert.NoError(t, err)
@@ -435,7 +408,7 @@ func TestDeleteVolume_Err_HasSecrets(t *testing.T) {
 	d := NewFakeDriver()
 	req := &csi.DeleteVolumeRequest{
 		VolumeId: fmt.Sprintf(volumeIDTemplate,
-			"testVolume", "testFs", "127.0.0.1", "testSubDir", false),
+			"testVolume", "testFs", "127.0.0.1", "testSubDir"),
 		Secrets: map[string]string{},
 	}
 	_, err := d.DeleteVolume(context.Background(), req)
@@ -450,7 +423,7 @@ func TestDeleteVolume_Err_HasSecretsValue(t *testing.T) {
 	d := NewFakeDriver()
 	req := &csi.DeleteVolumeRequest{
 		VolumeId: fmt.Sprintf(volumeIDTemplate,
-			"testVolume", "testFs", "127.0.0.1", "testSubDir", false),
+			"testVolume", "testFs", "127.0.0.1", "testSubDir"),
 		Secrets: map[string]string{
 			"test": "test",
 		},
@@ -467,7 +440,7 @@ func TestDeleteVolume_Err_OperationExists(t *testing.T) {
 	d := NewFakeDriver()
 	req := &csi.DeleteVolumeRequest{
 		VolumeId: fmt.Sprintf(volumeIDTemplate,
-			"testVolume", "testFs", "127.0.0.1", "testSubDir", false),
+			"testVolume", "testFs", "127.0.0.1", "testSubDir"),
 	}
 	if acquired := d.volumeLocks.TryAcquire(req.GetVolumeId()); !acquired {
 		assert.Fail(t, "Can't acquire volume lock")
@@ -496,7 +469,7 @@ func TestValidateVolumeCapabilities_Success(t *testing.T) {
 	}
 	req := &csi.ValidateVolumeCapabilitiesRequest{
 		VolumeId: fmt.Sprintf(volumeIDTemplate,
-			"test", "testFs", "127.0.0.1", "testSubDir", false),
+			"test", "testFs", "127.0.0.1", "testSubDir"),
 		VolumeCapabilities: capabilities,
 	}
 
@@ -535,7 +508,7 @@ func TestValidateVolumeCapabilities_Err_NoVolumeCapabilities(t *testing.T) {
 	d := NewFakeDriver()
 	req := &csi.ValidateVolumeCapabilitiesRequest{
 		VolumeId: fmt.Sprintf(volumeIDTemplate,
-			"test", "testFs", "127.0.0.1", "testSubDir", false),
+			"test", "testFs", "127.0.0.1", "testSubDir"),
 		VolumeCapabilities: nil,
 	}
 
@@ -551,7 +524,7 @@ func TestValidateVolumeCapabilities_Err_EmptyVolumeCapabilities(t *testing.T) {
 	d := NewFakeDriver()
 	req := &csi.ValidateVolumeCapabilitiesRequest{
 		VolumeId: fmt.Sprintf(volumeIDTemplate,
-			"test", "testFs", "127.0.0.1", "testSubDir", false),
+			"test", "testFs", "127.0.0.1", "testSubDir"),
 		VolumeCapabilities: []*csi.VolumeCapability{},
 	}
 
@@ -579,7 +552,7 @@ func TestValidateVolumeCapabilities_Err_HasSecretes(t *testing.T) {
 	}
 	req := &csi.ValidateVolumeCapabilitiesRequest{
 		VolumeId: fmt.Sprintf(volumeIDTemplate,
-			"test", "testFs", "127.0.0.1", "testSubDir", false),
+			"test", "testFs", "127.0.0.1", "testSubDir"),
 		VolumeCapabilities: capabilities,
 		Secrets:            map[string]string{},
 	}
@@ -608,7 +581,7 @@ func TestValidateVolumeCapabilities_Err_HasSecretesValue(t *testing.T) {
 	}
 	req := &csi.ValidateVolumeCapabilitiesRequest{
 		VolumeId: fmt.Sprintf(volumeIDTemplate,
-			"test", "testFs", "127.0.0.1", "testSubDir", false),
+			"test", "testFs", "127.0.0.1", "testSubDir"),
 		VolumeCapabilities: capabilities,
 		Secrets:            map[string]string{"test": "test"},
 	}
@@ -639,7 +612,7 @@ func TestValidateVolumeCapabilities_Success_BlockCapabilities(t *testing.T) {
 	}
 	req := &csi.ValidateVolumeCapabilitiesRequest{
 		VolumeId: fmt.Sprintf(volumeIDTemplate,
-			"test", "testFs", "127.0.0.1", "testSubDir", false),
+			"test", "testFs", "127.0.0.1", "testSubDir"),
 		VolumeCapabilities: capabilities,
 	}
 
@@ -684,7 +657,7 @@ func TestValidateVolumeCapabilities_Success_HasUnsupportedAccessMode(
 		}
 		req := &csi.ValidateVolumeCapabilitiesRequest{
 			VolumeId: fmt.Sprintf(volumeIDTemplate,
-				"test", "testFs", "127.0.0.1", "testSubDir", false),
+				"test", "testFs", "127.0.0.1", "testSubDir"),
 			VolumeCapabilities: capabilities,
 		}
 

--- a/test/external-e2e/e2etest_storageclass.yaml.template
+++ b/test/external-e2e/e2etest_storageclass.yaml.template
@@ -7,8 +7,7 @@ provisioner: azurelustre.csi.azure.com
 parameters:
   mgs-ip-address: "{lustre_mgs_ip}"
   fs-name: "{lustre_fs_name}"
-  #sub-dir: "longhaul/${pvc.metadata.name}"
-  #retain-sub-dir: "true"
+  #sub-dir: "longhaul"
 mountOptions:
   - noatime
   - flock

--- a/test/long-haul/cleanup/cleanupjob.yaml
+++ b/test/long-haul/cleanup/cleanupjob.yaml
@@ -8,7 +8,6 @@ parameters:
   mgs-ip-address: "{lustre_fs_ip}"
   fs-name: "{lustre_fs_name}"
   #sub-dir: "longhaul"
-  #retain-sub-dir: "false"
 
 ---
 kind: PersistentVolumeClaim

--- a/test/long-haul/sample-workload/deployment_write_print_file.yaml
+++ b/test/long-haul/sample-workload/deployment_write_print_file.yaml
@@ -7,8 +7,7 @@ provisioner: azurelustre.csi.azure.com
 parameters:
   mgs-ip-address: "{lustre_fs_ip}"
   fs-name: "{lustre_fs_name}"
-  #sub-dir: "longhaul/${pvc.metadata.name}"
-  #retain-sub-dir: "true"
+  #sub-dir: "longhaul"
 
 ---
 kind: PersistentVolumeClaim

--- a/test/scale/static_workload.yml.template
+++ b/test/scale/static_workload.yml.template
@@ -13,9 +13,8 @@ spec:
     volumeAttributes:
       fs-name: ${fs_name}
       mgs-ip-address: ${mgs_ip_address}
-      sub-dir: "longhaul/${pod.metadata.name}"
-      retain-sub-dir: "false"
-    volumeHandle: scale-pv-lustre#${fs_name}#${mgs_ip_address}#longhaul/${pod.metadata.name}#false
+      #sub-dir: "longhaul"
+    volumeHandle: scale-pv-lustre#${fs_name}#${mgs_ip_address}#longhaul/${pod.metadata.name}
   persistentVolumeReclaimPolicy: Retain
 
 ---


### PR DESCRIPTION
The retain-sub-dir feature is intended to allow the user to have their subdirectory data automatically cleaned up when a pod unmounts from the Lustre filesystem. However, based on test, in its current form it allows the user to easily get themselves into a bad state or to lose data. For this release, we will maintain the subdirectory creation and mounting logic, but will wait on any customer feedback before re-enabling this functionality based on expected use cases.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
