### PR TITLE
Defaulting to v0.1.15 CSI 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ REGISTRY ?= azurelustre.azurecr.io
 REGISTRY_NAME ?= $(shell echo $(REGISTRY) | sed "s/.azurecr.io//g")
 TARGET ?= csi
 IMAGE_NAME ?= azurelustre-$(TARGET)
-IMAGE_VERSION ?= v0.1.14
+IMAGE_VERSION ?= v0.1.15
 CLOUD ?= AzurePublicCloud
 # Use a custom version for E2E tests if we are in Prow
 ifdef CI

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ This driver allows Kubernetes to access Azure Lustre file system.
 
 | Driver version  | Image                                                         | Supported k8s version | Lustre client version |
 |-----------------|---------------------------------------------------------------|-----------------------|-----------------------|
-| main branch     | mcr.microsoft.com/oss/kubernetes-csi/azurelustre-csi:latest   | 1.21+                 | 2.15.1                |
+| main branch     | mcr.microsoft.com/oss/kubernetes-csi/azurelustre-csi:latest   | 1.21+                 | 2.15.4                |
 | v0.1.11         | mcr.microsoft.com/oss/kubernetes-csi/azurelustre-csi:v0.1.11  | 1.21+                 | 2.15.1                |
+| v0.1.14         | mcr.microsoft.com/oss/kubernetes-csi/azurelustre-csi:v0.1.14  | 1.21+                 | 2.15.3                |
+| v0.1.15         | mcr.microsoft.com/oss/kubernetes-csi/azurelustre-csi:v0.1.15  | 1.21+                 | 2.15.4                |
 
 &nbsp;
 

--- a/deploy/csi-azurelustre-controller.yaml
+++ b/deploy/csi-azurelustre-controller.yaml
@@ -68,7 +68,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: azurelustre
-          image: mcr.microsoft.com/oss/kubernetes-csi/azurelustre-csi:v0.1.14
+          image: mcr.microsoft.com/oss/kubernetes-csi/azurelustre-csi:v0.1.15
           imagePullPolicy: IfNotPresent
           args:
             - "-v=5"

--- a/deploy/csi-azurelustre-node.yaml
+++ b/deploy/csi-azurelustre-node.yaml
@@ -84,7 +84,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: azurelustre
-          image: mcr.microsoft.com/oss/kubernetes-csi/azurelustre-csi:v0.1.14
+          image: mcr.microsoft.com/oss/kubernetes-csi/azurelustre-csi:v0.1.15
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -116,9 +116,9 @@ spec:
             - name: AZURELUSTRE_CSI_INSTALL_LUSTRE_CLIENT
               value: "yes"
             - name: LUSTRE_VERSION
-              value: "2.15.3"
+              value: "2.15.4"
             - name: CLIENT_SHA_SUFFIX
-              value: "43-gd7e07df"
+              value: "42-gd6d405d"
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/docs/install-csi-driver.md
+++ b/docs/install-csi-driver.md
@@ -7,7 +7,7 @@ This document explains how to install Azure Lustre CSI driver on a kubernetes cl
 - Option 1: Remote install
 
     ```shell
-    curl -skSL https://raw.githubusercontent.com/kubernetes-sigs/azurelustre-csi-driver/main/deploy/install-driver.sh | bash -s main --
+    curl -skSL https://raw.githubusercontent.com/kubernetes-sigs/azurelustre-csi-driver/main/deploy/install-driver.sh | bash -s main
     ```
 
 - Option 2: Local install


### PR DESCRIPTION


**What type of PR is this?**

Add one of the following kinds:

/kind documentation
/kind feature


**What this PR does / why we need it**:
Moving CSI from v0.1.14 to v0.1.15.  Includes 2.15.4 client as well as a few Security/cleanup patches.

**Which issue(s) this PR fixes**:
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
* 2.15.4 Lustre Client
* install-driver.sh refactor
* Misc CVE/Doc fixes.
```
