### PR TITLE
Upgrade sidecars

### DIFF
--- a/deploy/csi-azurelustre-controller.yaml
+++ b/deploy/csi-azurelustre-controller.yaml
@@ -31,7 +31,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: csi-provisioner
-          image: mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v3.6.0
+          image: mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v5.1.0
           args:
             - "-v=2"
             - "--csi-address=$(ADDRESS)"
@@ -52,7 +52,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: liveness-probe
-          image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.9.0
+          image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.14.0
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=120s

--- a/deploy/csi-azurelustre-node.yaml
+++ b/deploy/csi-azurelustre-node.yaml
@@ -39,7 +39,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-          image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.9.0
+          image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.14.0
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=120s
@@ -53,7 +53,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: node-driver-registrar
-          image: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.9.0
+          image: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.12.0
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)

--- a/deploy/rbac-csi-azurelustre-controller.yaml
+++ b/deploy/rbac-csi-azurelustre-controller.yaml
@@ -13,7 +13,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]


### PR DESCRIPTION
Updates the sidecar versions to latest. The provisioner has more intelligent PV/PVC cleanup and so now needs 'patch' ability on PVs.