### PR TITLE
Use force unmount and explicitly unmount bad mount points

### DIFF
--- a/pkg/azurelustre/azurelustre.go
+++ b/pkg/azurelustre/azurelustre.go
@@ -91,6 +91,7 @@ type Driver struct {
 	// enableAzureLustreMockMount is only for testing, DO NOT set as true in non-testing scenario
 	enableAzureLustreMockMount bool
 	mounter                    *mount.SafeFormatAndMount // TODO_JUSJIN: check any other alternatives
+	forceMounter               *mount.MounterForceUnmounter
 	volLockMap                 *util.LockMap
 	// Directory to temporarily mount to for subdirectory creation
 	workingMountDir string
@@ -131,6 +132,13 @@ func (d *Driver) Run(endpoint string, testBool bool) {
 	d.mounter = &mount.SafeFormatAndMount{
 		Interface: mount.New(""),
 		Exec:      utilexec.New(),
+	}
+	forceUnmounter, ok := d.mounter.Interface.(mount.MounterForceUnmounter)
+	if ok {
+		klog.V(4).Infof("Using force unmounter interface")
+		d.forceMounter = &forceUnmounter
+	} else {
+		klog.Fatalf("Mounter does not support force unmount")
 	}
 
 	// TODO_JUSJIN: revisit these caps

--- a/pkg/azurelustre/fake_mount.go
+++ b/pkg/azurelustre/fake_mount.go
@@ -19,6 +19,7 @@ package azurelustre
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	mount "k8s.io/mount-utils"
 )
@@ -68,4 +69,8 @@ func (f *fakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+func (f *fakeMounter) UnmountWithForce(target string, _ time.Duration) error {
+	return f.Unmount(target)
 }

--- a/pkg/azurelustre/nodeserver_test.go
+++ b/pkg/azurelustre/nodeserver_test.go
@@ -115,6 +115,9 @@ func TestEnsureMountPoint(t *testing.T) {
 		Interface: fakeMounter,
 		Exec:      fakeExec,
 	}
+	forceMounter, ok := d.mounter.Interface.(mount.MounterForceUnmounter)
+	require.True(t, ok, "Mounter should implement MounterForceUnmounter")
+	d.forceMounter = &forceMounter
 
 	for _, test := range tests {
 		err := makeDir(alreadyExistTarget)
@@ -542,6 +545,9 @@ func TestNodePublishVolume(t *testing.T) {
 			Interface: fakeMounter,
 			Exec:      fakeExec,
 		}
+		forceMounter, ok := d.mounter.Interface.(mount.MounterForceUnmounter)
+		require.True(t, ok, "Mounter should implement MounterForceUnmounter")
+		d.forceMounter = &forceMounter
 		d.workingMountDir = workingMountDir
 		err := makeDir(targetTest)
 		require.NoError(t, err)
@@ -736,6 +742,9 @@ func TestNodeUnpublishVolume(t *testing.T) {
 			Interface: fakeMounter,
 			Exec:      fakeExec,
 		}
+		forceMounter, ok := d.mounter.Interface.(mount.MounterForceUnmounter)
+		require.True(t, ok, "Mounter should implement MounterForceUnmounter")
+		d.forceMounter = &forceMounter
 		err := makeDir(targetTest)
 		require.NoError(t, err)
 


### PR DESCRIPTION
There have been cases where the logic to cleanup a mount point has caused the driver to get into a bad state. This is most obvious when a subdirectory is mounted to a volume and a parent directory of that subdirectory is deleted. The Lustre driver doesn't handle that case in the way that Kubernetes expects and returns invalid data. To avoid this scenario causing our driver to get into a bad state, leak mount points, etc, we must explicitly check that we can read the necessary information about the mount point, and if not, explicitly unmount that mount point before allowing Kubernetes to clean up the directory. To ensure that we don't end up in a bad state, this change enables force unmounting as well. The force unmount will only occur after a timeout has expired, since force unmounts can cause issues with the Lustre driver. However, in this case, it is better if we are in a bad enough situation to be able to eventually return to a good state rather than require manual intervention.

**What type of PR is this?**

/kind bug
