### PR TITLE
Add cluster ping to publish

### DIFF
--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -959,7 +959,15 @@ kubectl exec -it csi-azurelustre-node-9ds7f -n kube-system -c azurelustre -- mou
 172.18.8.12@tcp:/lustrefs on /var/lib/kubelet/pods/6632349a-05fd-466f-bc8a-8946617089ce/volumes/kubernetes.io~csi/pvc-841498d9-fa63-418c-8cc7-d94ec27f2ee2/mount type lustre (rw,flock,lazystatfs,encrypt)
 ```
 
-> **Note:** It is expected for each mount mount to be listed twice
+> **Note:** It is expected for each mount point to be listed twice
+
+**Reachability is checked before mounting.** Before mounting, the driver checks reachability in two stages: a fast TCP dial to the LNet acceptor port (default `988`), then an `lnetctl ping`. A wrong or unreachable MGS IP fails the dial within about 5 seconds; if a port is open but the peer is not a healthy LNet endpoint, the `lnetctl ping` stage can take up to about 50 seconds before failing. If the MGS is unreachable, `NodePublishVolume` fails fast with a `FailedPrecondition` error (`MGS IP address ... is not reachable`) instead of letting the mount hang. Reproduce the same `lnetctl ping` the driver performs:
+
+```sh
+kubectl exec -it csi-azurelustre-node-jammy-9ds7f -n kube-system -c azurelustre -- lnetctl ping <mgs-ip>@tcp
+```
+
+> **Note:** The ping result is cached for about 20 seconds, so once connectivity is restored the mount will recover on retry.
 
 Check for solutions in [Resolving Common Errors](errors.md)
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -17,6 +17,7 @@ This document describes common errors that can occur during volume creation and 
 - [Volume Mounting Errors](#volume-mounting-errors)
   - [Node Mount Errors](#node-mount-errors)
     - [Error: Could not mount target](#error-could-not-mount-target)
+    - [Error: MGS IP address is not reachable](#error-mgs-ip-address-is-not-reachable)
     - [Error: Context sub-dir must be strict subpath](#error-context-sub-dir-must-be-strict-subpath)
 - [Configuration Errors](#configuration-errors)
   - [StorageClass Parameter Errors](#storageclass-parameter-errors)
@@ -341,6 +342,48 @@ kubectl get pv <pv-name> -o jsonpath='{.spec.csi.volumeAttributes.mgs-ip-address
 - Validate MGS IP address is correct and reachable
 - Check firewall rules and network security groups
 - Add NSG rules to allow AMLFS traffic if necessary
+
+---
+
+#### Error: MGS IP address is not reachable
+
+**Symptoms:**
+
+- Pod fails to start and stays in `ContainerCreating` status
+- Before mounting, the driver checks reachability in two stages: a fast TCP dial to the LNet acceptor port (default `988`), then an `lnetctl ping`. A wrong or unreachable MGS IP fails the dial within about 5 seconds. If a port is open but the peer is not a healthy LNet endpoint, the `lnetctl ping` stage can take up to about 50 seconds before failing (the LNet handshake is an in-kernel wait that cannot be shortened).
+- `NodePublishVolume` fails with:
+  - `MGS IP address "10.10.10.10" is not reachable; verify the cluster IP address and node network configuration are correct (if the cluster was only briefly unreachable, the operation will recover on retry)`
+- Error code: `FailedPrecondition`
+- Node logs show either `LNet reachability gate: dial to <mgs-ip>:988 failed` or `lnetctl ping to <mgs-ip>@tcp failed with error`
+
+**Possible Causes:**
+
+- Incorrect MGS IP address in the PersistentVolume or StorageClass
+- Missing or misconfigured virtual network peering or routing between the cluster and the AMLFS cluster
+- Network security group or firewall blocking LNet (TCP) traffic to the MGS
+- The AMLFS cluster is stopped, deleting, or otherwise temporarily unreachable
+- LNet is not configured correctly on the node (see [CSI Driver Troubleshooting Guide](csi-debug.md))
+
+**Debugging Steps:**
+
+```bash
+# Verify the MGS IP recorded on the volume
+kubectl get pv <pv-name> -o jsonpath='{.spec.csi.volumeAttributes.mgs-ip-address}'
+
+# Look for the reachability failure in the node driver logs
+kubectl logs -n kube-system csi-azurelustre-node-<pod> -c azurelustre --tail=300 | grep -iE 'reachability|ping'
+
+# Reproduce the reachability check from the node pod
+kubectl exec -n kube-system csi-azurelustre-node-<pod> -c azurelustre -- lnetctl ping <mgs-ip>@tcp
+```
+
+**Resolution:**
+
+- Correct the MGS IP address in the PersistentVolume or StorageClass if it is wrong
+- Verify virtual network peering and routing between the cluster and the AMLFS cluster
+- Add NSG or firewall rules to allow LNet (TCP) traffic to the MGS
+- Confirm the AMLFS cluster is running and healthy in the Azure portal
+- The check result is cached briefly (about 20 seconds); once connectivity is restored, the operation will recover on retry
 
 ---
 

--- a/pkg/azurelustre/azurelustre.go
+++ b/pkg/azurelustre/azurelustre.go
@@ -41,6 +41,7 @@ import (
 	csicommon "sigs.k8s.io/azurelustre-csi-driver/pkg/csi-common"
 	"sigs.k8s.io/azurelustre-csi-driver/pkg/util"
 	"sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader"
+	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	azure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 	azureconfig "sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
 )
@@ -151,6 +152,8 @@ type Driver struct {
 	resourceGroup      string
 	location           string
 	dynamicProvisioner DynamicProvisionerInterface
+	commandRunner      util.CommandRunnerInterface
+	pingCache          azcache.Resource
 
 	removeNotReadyTaint bool
 	kubeClient          kubernetes.Interface
@@ -170,6 +173,7 @@ func NewDriver(options *DriverOptions) *Driver {
 		enableAzureLustreMockDynProv: options.EnableAzureLustreMockDynProv,
 		workingMountDir:              options.WorkingMountDir,
 		removeNotReadyTaint:          options.RemoveNotReadyTaint,
+		commandRunner:                &util.DefaultCommandRunner{},
 	}
 	d.Name = options.DriverName
 	d.Version = driverVersion
@@ -261,6 +265,10 @@ func NewDriver(options *DriverOptions) *Driver {
 			vnetClient:           vnetClient,
 			skusClient:           skusClient,
 		}
+	}
+
+	if d.pingCache, err = azcache.NewTimedCache(20*time.Second, d.pingCluster, false); err != nil {
+		klog.Fatalf("%v", err)
 	}
 
 	return &d

--- a/pkg/azurelustre/azurelustre.go
+++ b/pkg/azurelustre/azurelustre.go
@@ -170,6 +170,7 @@ type Driver struct {
 	resourceGroup      string
 	location           string
 	dynamicProvisioner DynamicProvisionerInterface
+	pingChecker        clusterPingChecker
 
 	removeNotReadyTaint bool
 	kubeClient          kubernetes.Interface
@@ -256,6 +257,10 @@ func NewDriver(options *DriverOptions) (*Driver, error) {
 				return nil, err
 			}
 		}
+	}
+
+	if d.pingChecker, err = newClusterPingCache(&util.DefaultCommandRunner{}); err != nil {
+		klog.Fatalf("%v", err)
 	}
 
 	return &d, nil

--- a/pkg/azurelustre/azurelustre_test.go
+++ b/pkg/azurelustre/azurelustre_test.go
@@ -39,6 +39,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/azurelustre-csi-driver/pkg/util"
+	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	azure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 )
 
@@ -56,6 +58,7 @@ const (
 	clusterRequestFailureName = "testShouldFail"
 	driverDefaultLocation     = "defaultFakeLocation"
 	emptyZonesLocation        = "emptyZonesLocation"
+	fakeCacheTTL              = 1 * time.Second
 )
 
 func NewFakeDriver() *Driver {
@@ -72,8 +75,37 @@ func NewFakeDriver() *Driver {
 	driver.location = driverDefaultLocation
 	driver.resourceGroup = "defaultFakeResourceGroup"
 	driver.dynamicProvisioner = &FakeDynamicProvisioner{}
+	driver.commandRunner = NewFakeCommandRunner(false)
+
+	getter := func(_ context.Context, _ string) (interface{}, error) {
+		return true, nil
+	}
+
+	driver.pingCache, _ = azcache.NewTimedCache(fakeCacheTTL, getter, false) //nolint:errcheck // TimedCache never returns error here
+	driver.pingCache.Set("key", nil)
 
 	return driver
+}
+
+type FakeCommandRunner struct {
+	util.CommandRunnerInterface
+	CalledCommands []string
+	cmdShouldFail  bool
+}
+
+func NewFakeCommandRunner(shouldFail bool) *FakeCommandRunner {
+	return &FakeCommandRunner{
+		CalledCommands: []string{},
+		cmdShouldFail:  shouldFail,
+	}
+}
+
+func (f *FakeCommandRunner) RunWithTimeout(_ context.Context, _ time.Duration, cmd string, args ...string) (string, error) {
+	f.CalledCommands = append(f.CalledCommands, fmt.Sprintf("%s %s", cmd, strings.Join(args, " ")))
+	if f.cmdShouldFail {
+		return "", errors.New("error occurred calling command: " + cmd)
+	}
+	return "fake command output", nil
 }
 
 type FakeDynamicProvisioner struct {

--- a/pkg/azurelustre/azurelustre_test.go
+++ b/pkg/azurelustre/azurelustre_test.go
@@ -77,6 +77,7 @@ func NewFakeDriver(t *testing.T) *Driver {
 	driver.location = driverDefaultLocation
 	driver.resourceGroup = "defaultFakeResourceGroup"
 	driver.dynamicProvisioner = &FakeDynamicProvisioner{}
+	driver.pingChecker = &fakePingChecker{}
 
 	return driver
 }
@@ -94,6 +95,34 @@ func writeFakeCloudConfig(t *testing.T) string {
 }`
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
 	return path
+}
+
+type FakeCommandRunner struct {
+	CalledCommands []string
+	cmdShouldFail  bool
+}
+
+func NewFakeCommandRunner(shouldFail bool) *FakeCommandRunner {
+	return &FakeCommandRunner{
+		CalledCommands: []string{},
+		cmdShouldFail:  shouldFail,
+	}
+}
+
+func (f *FakeCommandRunner) RunWithTimeout(_ context.Context, _ time.Duration, cmd string, args ...string) (string, error) {
+	f.CalledCommands = append(f.CalledCommands, fmt.Sprintf("%s %s", cmd, strings.Join(args, " ")))
+	if f.cmdShouldFail {
+		return "", errors.New("error occurred calling command: " + cmd)
+	}
+	return "fake command output", nil
+}
+
+type fakePingChecker struct {
+	err error
+}
+
+func (f *fakePingChecker) EnsureReachable(_ string) error {
+	return f.err
 }
 
 type FakeDynamicProvisioner struct {

--- a/pkg/azurelustre/nodeserver.go
+++ b/pkg/azurelustre/nodeserver.go
@@ -31,12 +31,41 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 	mount "k8s.io/mount-utils"
 	volumehelper "sigs.k8s.io/azurelustre-csi-driver/pkg/util"
+	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
 	"sigs.k8s.io/cloud-provider-azure/pkg/metrics"
 )
 
+// pingCluster used as the getter function for pingCache. Pings the MGS IP address to see if it's reachable.
+// Allows the ping to timeout after 5 seconds to avoid long delays
+func (d *Driver) pingCluster(ctx context.Context, mgsIPAddress string) (interface{}, error) {
+	pingAddr := fmt.Sprintf("%s@tcp", mgsIPAddress)
+	_, err := d.commandRunner.RunWithTimeout(ctx, 5*time.Second, "lnetctl", "ping", pingAddr)
+	if err != nil {
+		klog.Warningf("lnetctl ping to %s failed with error: %v", pingAddr, err)
+		return false, nil
+	}
+	return true, nil
+}
+
+// getCachedClusterPing checks whether the MGS IP address is reachable by looking it up in the pingCache.
+// If not found or expired, it will ping the MGS IP address and update the cache.
+func (d *Driver) getCachedClusterPing(ctx context.Context, mgsIPAddress string) error {
+	cacheData, err := d.pingCache.Get(ctx, mgsIPAddress, azcache.CacheReadTypeDefault)
+	if err != nil {
+		return status.Errorf(codes.Internal, "error getting pingCache value for MGS IP %q: %v", mgsIPAddress, err)
+	}
+	if pinged, ok := cacheData.(bool); !ok {
+		return status.Error(codes.Internal, "type assertion failed for pingCache value")
+	} else if !pinged {
+		return status.Errorf(codes.InvalidArgument,
+			"MGS IP address %q didn't respond to lnetctl ping: Is the cluster IP address correct and the network configured correctly?", mgsIPAddress)
+	}
+	return nil
+}
+
 // NodePublishVolume mount the volume from staging to target path
 func (d *Driver) NodePublishVolume(
-	_ context.Context,
+	ctx context.Context,
 	req *csi.NodePublishVolumeRequest,
 ) (*csi.NodePublishVolumeResponse, error) {
 	mc := metrics.NewMetricContext(azureLustreCSIDriverName,
@@ -64,13 +93,13 @@ func (d *Driver) NodePublishVolume(
 			"Target path not provided")
 	}
 
-	context := req.GetVolumeContext()
-	if context == nil {
+	volumeContext := req.GetVolumeContext()
+	if volumeContext == nil {
 		return nil, status.Error(codes.InvalidArgument,
 			"Volume context must be provided")
 	}
 
-	vol, err := getVolume(volumeID, context)
+	vol, err := getVolume(volumeID, volumeContext)
 	if err != nil {
 		return nil, err
 	}
@@ -88,12 +117,20 @@ func (d *Driver) NodePublishVolume(
 		mc.ObserveOperationWithResult(isOperationSucceeded)
 	}()
 
+	if !d.enableAzureLustreMockMount {
+		klog.V(2).Infof("NodePublishVolume: ensuring MGS IP address %s responds to ping before attempting mount", vol.mgsIPAddress)
+		if err := d.getCachedClusterPing(ctx, vol.mgsIPAddress); err != nil {
+			return nil, err
+		}
+		klog.V(2).Infof("NodePublishVolume: ping to MGS IP address %s successful", vol.mgsIPAddress)
+	}
+
 	source := getSourceString(vol.mgsIPAddress, vol.azureLustreName)
 
 	mountOptions, readOnly := getMountOptions(req, userMountFlags)
 
 	if len(vol.subDir) > 0 && !d.enableAzureLustreMockMount {
-		interpolatedSubDir := interpolateSubDirVariables(context, vol)
+		interpolatedSubDir := interpolateSubDirVariables(volumeContext, vol)
 
 		if isSubpath := ensureStrictSubpath(interpolatedSubDir); !isSubpath {
 			return nil, status.Error(

--- a/pkg/azurelustre/nodeserver.go
+++ b/pkg/azurelustre/nodeserver.go
@@ -64,13 +64,13 @@ func (d *Driver) NodePublishVolume(
 			"Target path not provided")
 	}
 
-	context := req.GetVolumeContext()
-	if context == nil {
+	volumeContext := req.GetVolumeContext()
+	if volumeContext == nil {
 		return nil, status.Error(codes.InvalidArgument,
 			"Volume context must be provided")
 	}
 
-	vol, err := getVolume(volumeID, context)
+	vol, err := getVolume(volumeID, volumeContext)
 	if err != nil {
 		return nil, err
 	}
@@ -88,12 +88,42 @@ func (d *Driver) NodePublishVolume(
 		mc.ObserveOperationWithResult(isOperationSucceeded)
 	}()
 
+	// Check whether the target is already mounted before doing anything that requires
+	// the MGS to be reachable. NodePublishVolume must be idempotent: a retry against an
+	// already-published target has to return OK even if the cluster is briefly
+	// unreachable, so this fast path runs ahead of the ping check and the sub-dir setup
+	// (which itself mounts the MGS).
+	mnt, err := d.ensureMountPoint(target)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"Could not mount target %q: %v",
+			target,
+			err)
+	}
+	if mnt {
+		klog.V(2).Infof(
+			"NodePublishVolume: volume %s is already mounted on %s",
+			volumeID,
+			target,
+		)
+		isOperationSucceeded = true
+		return &csi.NodePublishVolumeResponse{}, nil
+	}
+
+	if !d.enableAzureLustreMockMount {
+		klog.V(2).Infof("NodePublishVolume: ensuring MGS IP address %s responds to ping before attempting mount", vol.mgsIPAddress)
+		if err := d.pingChecker.EnsureReachable(vol.mgsIPAddress); err != nil {
+			return nil, err
+		}
+		klog.V(2).Infof("NodePublishVolume: ping to MGS IP address %s successful", vol.mgsIPAddress)
+	}
+
 	source := getSourceString(vol.mgsIPAddress, vol.azureLustreName)
 
 	mountOptions, readOnly := getMountOptions(req, userMountFlags)
 
 	if len(vol.subDir) > 0 && !d.enableAzureLustreMockMount {
-		interpolatedSubDir := interpolateSubDirVariables(context, vol)
+		interpolatedSubDir := interpolateSubDirVariables(volumeContext, vol)
 
 		if isSubpath := ensureStrictSubpath(interpolatedSubDir); !isSubpath {
 			return nil, status.Error(
@@ -120,22 +150,6 @@ func (d *Driver) NodePublishVolume(
 			"NodePublishVolume: full mount source with sub-dir: %q",
 			source,
 		)
-	}
-
-	mnt, err := d.ensureMountPoint(target)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"Could not mount target %q: %v",
-			target,
-			err)
-	}
-	if mnt {
-		klog.V(2).Infof(
-			"NodePublishVolume: volume %s is already mounted on %s",
-			volumeID,
-			target,
-		)
-		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
 	klog.V(2).Infof(

--- a/pkg/azurelustre/nodeserver_test.go
+++ b/pkg/azurelustre/nodeserver_test.go
@@ -521,11 +521,25 @@ func TestNodePublishVolume(t *testing.T) {
 				d.volumeLocks.Release(lockKey)
 			},
 		},
+		{
+			desc: "Error failed ping to MGS",
+			setup: func(d *Driver) {
+				d.pingCache.Set("1.1.1.1", false)
+			},
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1#lustrefs#1.1.1.1#",
+				TargetPath:       targetTest,
+				VolumeContext:    map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs"},
+			},
+			expectedErr:          status.Error(codes.InvalidArgument, "MGS IP address \"1.1.1.1\" didn't respond to lnetctl ping: Is the cluster IP address correct and the network configured correctly?"),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
+		},
 	}
 
-	d := NewFakeDriver()
-
 	for i := range tests {
+		d := NewFakeDriver()
 		test := &tests[i]
 
 		fakeMounter := &fakeMounter{}

--- a/pkg/azurelustre/nodeserver_test.go
+++ b/pkg/azurelustre/nodeserver_test.go
@@ -489,6 +489,22 @@ func TestNodePublishVolume(t *testing.T) {
 			expectedMountActions: []mount.FakeAction{},
 		},
 		{
+			desc: "Success already mounted returns OK even when cluster ping is unreachable",
+			setup: func(d *Driver) {
+				d.pingChecker = &fakePingChecker{err: status.Error(codes.FailedPrecondition, "MGS IP address is not reachable")}
+			},
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1#lustrefs#1.1.1.1#testSubDir",
+				TargetPath:       alreadyExistTarget,
+				VolumeContext:    map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs", "sub-dir": subDir},
+				Readonly:         true,
+			},
+			expectedErr:          nil,
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
+		},
+		{
 			desc: "Error could not mount",
 			req: csi.NodePublishVolumeRequest{
 				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
@@ -521,11 +537,25 @@ func TestNodePublishVolume(t *testing.T) {
 				d.volumeLocks.Release(lockKey)
 			},
 		},
+		{
+			desc: "Error failed ping to MGS",
+			setup: func(d *Driver) {
+				d.pingChecker = &fakePingChecker{err: status.Error(codes.FailedPrecondition, "MGS IP address is not reachable")}
+			},
+			req: csi.NodePublishVolumeRequest{
+				VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap},
+				VolumeId:         "vol_1#lustrefs#1.1.1.1#",
+				TargetPath:       targetTest,
+				VolumeContext:    map[string]string{"mgs-ip-address": "1.1.1.1", "fs-name": "lustrefs"},
+			},
+			expectedErr:          status.Error(codes.FailedPrecondition, "MGS IP address is not reachable"),
+			expectedMountpoints:  nil,
+			expectedMountActions: []mount.FakeAction{},
+		},
 	}
 
-	d := NewFakeDriver(t)
-
 	for i := range tests {
+		d := NewFakeDriver(t)
 		test := &tests[i]
 
 		fakeMounter := &fakeMounter{}

--- a/pkg/azurelustre/pingcache.go
+++ b/pkg/azurelustre/pingcache.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azurelustre
+
+import (
+	"context"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/azurelustre-csi-driver/pkg/util"
+	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+)
+
+const (
+	clusterPingCacheTTL = 20 * time.Second
+	dialTimeout         = 5 * time.Second
+	// A timeout can't actually bound the ping: lnetctl's LNet handshake is an uninterruptible
+	// in-kernel wait (~lnet_lnd_timeout, ~50s) that no timeout shortens. This only catches a truly
+	// stuck process.
+	lnetctlPingTimeout = 60 * time.Second
+
+	defaultAcceptorPort     = "988"
+	defaultAcceptorPortPath = "/sys/module/lnet/parameters/accept_port"
+)
+
+// clusterPingChecker reports whether a Lustre MGS is reachable from this node.
+type clusterPingChecker interface {
+	EnsureReachable(mgsIPAddress string) error
+}
+
+// clusterPingCache wraps azcache.TimedCache to give callers a typed EnsureReachable instead of the
+// untyped getter, cache-read-type argument, and context plumbing.
+type clusterPingCache struct {
+	cache         azcache.Resource
+	commandRunner util.CommandRunnerInterface
+	// dial and acceptorPortPath are fields only so tests can substitute a fake dialer and a sysfs
+	// fixture without real network or node access.
+	dial             func(ctx context.Context, network, address string) (net.Conn, error)
+	acceptorPortPath string
+}
+
+func newClusterPingCache(commandRunner util.CommandRunnerInterface) (*clusterPingCache, error) {
+	c := &clusterPingCache{
+		commandRunner:    commandRunner,
+		dial:             (&net.Dialer{Timeout: dialTimeout}).DialContext,
+		acceptorPortPath: defaultAcceptorPortPath,
+	}
+
+	cache, err := azcache.NewTimedCache(clusterPingCacheTTL, c.probe, false)
+	if err != nil {
+		return nil, err
+	}
+	c.cache = cache
+
+	return c, nil
+}
+
+// LNet uses one acceptor port fabric-wide, so this node's own configured port is also the port the
+// MGS listens on.
+func (c *clusterPingCache) acceptorPort() string {
+	if b, err := os.ReadFile(c.acceptorPortPath); err == nil {
+		if p := strings.TrimSpace(string(b)); p != "" {
+			return p
+		}
+	}
+	return defaultAcceptorPort
+}
+
+// probe returns false (not an error) when a stage fails, so a transient failure is cached as
+// "unreachable" instead of surfacing to callers as an internal cache error.
+func (c *clusterPingCache) probe(ctx context.Context, mgsIPAddress string) (any, error) {
+	dialAddr := net.JoinHostPort(mgsIPAddress, c.acceptorPort())
+	conn, err := c.dial(ctx, "tcp", dialAddr)
+	if err != nil {
+		klog.Warningf("LNet reachability gate: dial to %s failed: %v", dialAddr, err)
+		return false, nil
+	}
+	// The dial succeeding is what proves reachability; a Close error is incidental, so only log it.
+	if cerr := conn.Close(); cerr != nil {
+		klog.V(4).Infof("closing reachability dial to %s: %v", dialAddr, cerr)
+	}
+
+	pingAddr := mgsIPAddress + "@tcp"
+	if output, err := c.commandRunner.RunWithTimeout(ctx, lnetctlPingTimeout, "lnetctl", "ping", pingAddr); err != nil {
+		klog.Warningf("lnetctl ping to %s failed with error: %v, output: %s", pingAddr, err, output)
+		return false, nil
+	}
+	return true, nil
+}
+
+// EnsureReachable uses a background context, not the caller's: the cached result is shared by every
+// volume on this MGS, so one request's cancellation must not poison the shared probe.
+func (c *clusterPingCache) EnsureReachable(mgsIPAddress string) error {
+	cacheData, err := c.cache.Get(context.Background(), mgsIPAddress, azcache.CacheReadTypeDefault)
+	if err != nil {
+		return status.Errorf(codes.Internal, "error getting pingCache value for MGS IP %q: %v", mgsIPAddress, err)
+	}
+
+	pinged, ok := cacheData.(bool)
+	if !ok {
+		return status.Error(codes.Internal, "type assertion failed for pingCache value")
+	}
+	if !pinged {
+		klog.Warningf("MGS IP address %s is not reachable (cached result)", mgsIPAddress)
+		return status.Errorf(codes.FailedPrecondition,
+			"MGS IP address %q is not reachable; verify the cluster IP address and node network configuration are correct (if the cluster was only briefly unreachable, the operation will recover on retry)", mgsIPAddress)
+	}
+
+	return nil
+}

--- a/pkg/azurelustre/pingcache_test.go
+++ b/pkg/azurelustre/pingcache_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azurelustre
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	azcache "sigs.k8s.io/cloud-provider-azure/pkg/cache"
+)
+
+// fakeConn is a net.Conn stub for tests; probe only calls Close on the connection it dials, so
+// closeErr lets a test simulate a close failure.
+type fakeConn struct {
+	net.Conn
+	closeErr error
+}
+
+func (c fakeConn) Close() error { return c.closeErr }
+
+func TestClusterPingCacheProbe(t *testing.T) {
+	dialOpenPort := func(context.Context, string, string) (net.Conn, error) { return fakeConn{}, nil }
+	dialCloseErr := func(context.Context, string, string) (net.Conn, error) {
+		return fakeConn{closeErr: errors.New("close failed")}, nil
+	}
+	dialUnreachable := func(context.Context, string, string) (net.Conn, error) {
+		return nil, errors.New("connection refused")
+	}
+
+	tests := []struct {
+		desc              string
+		dial              func(context.Context, string, string) (net.Conn, error)
+		pingFails         bool
+		wantReachable     bool
+		wantPingAttempted bool
+	}{
+		{
+			desc:              "port open and lnetctl ping succeeds",
+			dial:              dialOpenPort,
+			pingFails:         false,
+			wantReachable:     true,
+			wantPingAttempted: true,
+		},
+		{
+			desc:              "port open but conn close errors, ping still succeeds",
+			dial:              dialCloseErr,
+			pingFails:         false,
+			wantReachable:     true,
+			wantPingAttempted: true,
+		},
+		{
+			desc:              "port open but lnetctl ping fails",
+			dial:              dialOpenPort,
+			pingFails:         true,
+			wantReachable:     false,
+			wantPingAttempted: true,
+		},
+		{
+			desc:              "port unreachable so lnetctl ping is skipped",
+			dial:              dialUnreachable,
+			pingFails:         false,
+			wantReachable:     false,
+			wantPingAttempted: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			fakeRunner := NewFakeCommandRunner(test.pingFails)
+			c := &clusterPingCache{commandRunner: fakeRunner, dial: test.dial}
+
+			result, err := c.probe(context.Background(), "1.1.1.1")
+			require.NoError(t, err)
+
+			reachable, ok := result.(bool)
+			require.True(t, ok, "probe result should be a bool")
+			assert.Equal(t, test.wantReachable, reachable)
+
+			if test.wantPingAttempted {
+				assert.Equal(t, []string{"lnetctl ping 1.1.1.1@tcp"}, fakeRunner.CalledCommands, "probe must invoke lnetctl with the <ip>@tcp NID once the port is open")
+			} else {
+				assert.Empty(t, fakeRunner.CalledCommands, "probe must not run lnetctl when the port is unreachable")
+			}
+		})
+	}
+}
+
+func TestClusterPingCacheAcceptorPort(t *testing.T) {
+	missing := &clusterPingCache{acceptorPortPath: filepath.Join(t.TempDir(), "missing")}
+	assert.Equal(t, defaultAcceptorPort, missing.acceptorPort(), "should fall back to the default when the sysfs file is missing")
+
+	portFile := filepath.Join(t.TempDir(), "accept_port")
+	require.NoError(t, os.WriteFile(portFile, []byte("1988\n"), 0o600))
+	configured := &clusterPingCache{acceptorPortPath: portFile}
+	assert.Equal(t, "1988", configured.acceptorPort(), "should read and trim the node's configured acceptor port")
+}
+
+func TestClusterPingCacheEnsureReachable(t *testing.T) {
+	tests := []struct {
+		desc         string
+		getter       func(context.Context, string) (any, error)
+		expectedCode codes.Code
+		expectedMsg  string
+	}{
+		{
+			desc: "cache contains reachable ping result",
+			getter: func(context.Context, string) (any, error) {
+				return true, nil
+			},
+			expectedCode: codes.OK,
+		},
+		{
+			desc: "cache contains unreachable ping result",
+			getter: func(context.Context, string) (any, error) {
+				return false, nil
+			},
+			expectedCode: codes.FailedPrecondition,
+			expectedMsg:  "is not reachable",
+		},
+		{
+			desc: "cache value type assertion fails",
+			getter: func(context.Context, string) (any, error) {
+				return "not-a-bool", nil
+			},
+			expectedCode: codes.Internal,
+			expectedMsg:  "type assertion failed for pingCache value",
+		},
+		{
+			desc: "cache getter returns error",
+			getter: func(context.Context, string) (any, error) {
+				return nil, errors.New("cache getter failure")
+			},
+			expectedCode: codes.Internal,
+			expectedMsg:  "error getting pingCache value",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			cache, err := azcache.NewTimedCache(1*time.Second, test.getter, false)
+			require.NoError(t, err)
+			c := &clusterPingCache{cache: cache}
+
+			err = c.EnsureReachable("1.1.1.1")
+			if test.expectedCode == codes.OK {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Equal(t, test.expectedCode, status.Code(err))
+			assert.Contains(t, err.Error(), test.expectedMsg)
+		})
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,10 +17,13 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
+	"time"
 )
 
 const (
@@ -85,6 +88,26 @@ func MakeDir(pathname string) error {
 		}
 	}
 	return nil
+}
+
+type CommandRunnerInterface interface {
+	RunWithTimeout(ctx context.Context, timeout time.Duration, cmd string, args ...string) (string, error)
+}
+
+type DefaultCommandRunner struct {
+	CommandRunnerInterface
+}
+
+func (r *DefaultCommandRunner) RunWithTimeout(ctx context.Context, timeout time.Duration, cmd string, args ...string) (string, error) {
+	cmdTimeout, cmdCancel := context.WithTimeout(ctx, timeout)
+	defer cmdCancel()
+
+	command := exec.CommandContext(cmdTimeout, cmd, args...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return string(output), nil
 }
 
 // LockMap used to lock on entries

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,10 +17,13 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
+	"time"
 )
 
 const (
@@ -85,6 +88,24 @@ func MakeDir(pathname string) error {
 		}
 	}
 	return nil
+}
+
+type CommandRunnerInterface interface {
+	RunWithTimeout(ctx context.Context, timeout time.Duration, cmd string, args ...string) (string, error)
+}
+
+type DefaultCommandRunner struct{}
+
+func (r *DefaultCommandRunner) RunWithTimeout(ctx context.Context, timeout time.Duration, cmd string, args ...string) (string, error) {
+	cmdTimeout, cmdCancel := context.WithTimeout(ctx, timeout)
+	defer cmdCancel()
+
+	command := exec.CommandContext(cmdTimeout, cmd, args...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return string(output), err
+	}
+	return string(output), nil
 }
 
 // LockMap used to lock on entries

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"errors"
 	"os"
 	"reflect"
@@ -40,6 +41,30 @@ func TestRoundUpGiB(t *testing.T) {
 	if actual != 1 {
 		t.Fatalf("Wrong result for RoundUpGiB. Got: %d", actual)
 	}
+}
+
+func TestCommandRunnerSuccess(t *testing.T) {
+	runner := &DefaultCommandRunner{}
+
+	output, err := runner.RunWithTimeout(context.Background(), 1*time.Second, "echo", "hello")
+	require.NoError(t, err)
+	require.Equal(t, "hello\n", output)
+}
+
+func TestCommandRunnerTimeout(t *testing.T) {
+	runner := &DefaultCommandRunner{}
+	output, err := runner.RunWithTimeout(context.Background(), 1*time.Second, "sleep", "10")
+	require.ErrorContains(t, err, "killed")
+	require.Empty(t, output, "Expected no output on timeout")
+}
+
+func TestCommandRunnerError(t *testing.T) {
+	runner := &DefaultCommandRunner{}
+
+	nonexistentPath := "./non-existent-path"
+	output, err := runner.RunWithTimeout(context.Background(), 1*time.Second, "ls", nonexistentPath)
+	require.Error(t, err)
+	require.Contains(t, output, nonexistentPath)
 }
 
 func TestSimpleLockEntry(t *testing.T) {


### PR DESCRIPTION
If the IP address for a cluster is not reachable, it takes a very long time for the mount to time out, holding up K8S operations and preventing quick deletion of incorrect volumes.

This change adds ping operation to ensure that the node is able to communicate with the expected cluster before attempting the mount operation. The result is cached for 20 seconds to prevent overwhelming the API if many volumes are being published in a short period of time.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
