### PR TITLE
Add Workload Identity support for AKS extension onboarding

### DIFF
--- a/deploy/csi-azurelustre-controller.yaml
+++ b/deploy/csi-azurelustre-controller.yaml
@@ -13,11 +13,15 @@ spec:
     metadata:
       labels:
         app: csi-azurelustre-controller
+        azure.workload.identity/use: "true"
     spec:
       serviceAccountName: csi-azurelustre-controller-sa
       nodeSelector:
         kubernetes.io/os: linux  # add "kubernetes.io/role: master" to run controller on master node
       priorityClassName: system-cluster-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
@@ -50,6 +54,10 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
         - name: liveness-probe
           image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.15.0
           args:
@@ -66,6 +74,10 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
         - name: azurelustre
           image: mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy
           imagePullPolicy: Always

--- a/deploy/csi-azurelustre-node-jammy.yaml
+++ b/deploy/csi-azurelustre-node-jammy.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         app: csi-azurelustre-node
         flavor: jammy
+        azure.workload.identity/use: "true"
     spec:
       hostNetwork: true
       dnsPolicy: Default
@@ -39,6 +40,9 @@ spec:
                       - Ubuntu2204
                       - Ubuntu2004  # To support CVM nodes still on 20.04
       priorityClassName: system-node-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
         - operator: "Exists"
       containers:
@@ -59,6 +63,10 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
         - name: node-driver-registrar
           image: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.13.0
           args:
@@ -90,6 +98,10 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
         - name: azurelustre
           image: mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy
           imagePullPolicy: Always

--- a/deploy/csi-azurelustre-node-noble.yaml
+++ b/deploy/csi-azurelustre-node-noble.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         app: csi-azurelustre-node
         flavor: noble
+        azure.workload.identity/use: "true"
     spec:
       hostNetwork: true
       dnsPolicy: Default
@@ -35,6 +36,9 @@ spec:
                     values:
                       - virtual-kubelet
       priorityClassName: system-node-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
         - operator: "Exists"
       containers:
@@ -55,6 +59,10 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
         - name: node-driver-registrar
           image: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.13.0
           args:
@@ -86,6 +94,10 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
         - name: azurelustre
           image: mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-noble
           imagePullPolicy: Always

--- a/deploy/rbac-csi-azurelustre-controller.yaml
+++ b/deploy/rbac-csi-azurelustre-controller.yaml
@@ -4,6 +4,12 @@ kind: ServiceAccount
 metadata:
   name: csi-azurelustre-controller-sa
   namespace: kube-system
+  labels:
+    azure.workload.identity/use: "true"
+  # To use workload identity, uncomment and set the client-id annotation:
+  # annotations:
+  #   azure.workload.identity/client-id: "<AZURE_CLIENT_ID>"
+  #   azure.workload.identity/tenant-id: "<AZURE_TENANT_ID>"  # optional, if cross-tenant
 ---
 
 kind: ClusterRole

--- a/deploy/rbac-csi-azurelustre-node.yaml
+++ b/deploy/rbac-csi-azurelustre-node.yaml
@@ -4,6 +4,12 @@ kind: ServiceAccount
 metadata:
   name: csi-azurelustre-node-sa
   namespace: kube-system
+  labels:
+    azure.workload.identity/use: "true"
+  # To use workload identity, uncomment and set the client-id annotation:
+  # annotations:
+  #   azure.workload.identity/client-id: "<AZURE_CLIENT_ID>"
+  #   azure.workload.identity/tenant-id: "<AZURE_TENANT_ID>"  # optional, if cross-tenant
 
 ---
 kind: ClusterRole

--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -33,6 +33,8 @@ This mechanism prevents pods requiring Azure Lustre storage from being scheduled
 
 See [Use a managed identity in Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/use-managed-identity) for information about configuring your kubelet identity.
 
+Alternatively, you can use [Workload Identity](workload-identity.md) for authentication, which is recommended for AKS clusters and is required for AKS extension support.
+
 The kubelet identity attached to the cluster will require the following permission actions (at the Subscription scope):
 
 ```text

--- a/docs/workload-identity.md
+++ b/docs/workload-identity.md
@@ -1,0 +1,131 @@
+# Workload Identity Support
+
+The Azure Lustre CSI driver supports [Microsoft Entra Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview) for authenticating to Azure when using dynamic provisioning. When configured, the driver uses a federated identity credential instead of the node's managed identity to make Azure Resource Manager API calls.
+
+> **Note:** Workload Identity is only required for **dynamic provisioning** (creating and deleting Azure Managed Lustre filesystem resources). Static provisioning (mounting an existing AMLFS cluster) uses kernel Lustre mounts over the network and does not require Azure authentication.
+
+## Authentication Modes
+
+The CSI driver uses `DefaultAzureCredential` from the Azure Identity SDK, which supports multiple authentication methods. The deploy manifests include `azure.workload.identity/use: "true"` labels on the pod templates, which enables the AKS workload identity webhook to inject credentials when configured.
+
+### Workload Identity (recommended for AKS)
+
+When the controller service account is annotated with a `client-id`, the AKS webhook injects `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_FEDERATED_TOKEN_FILE` into the controller pods. `DefaultAzureCredential` detects these and authenticates via `WorkloadIdentityCredential`.
+
+**This is the recommended mode** and is required for AKS extension support.
+
+### Managed Identity (clusters without workload identity)
+
+On AKS clusters created **without** `--enable-workload-identity` (or non-AKS clusters), the workload identity webhook is not present. The pod labels have no effect and no WI env vars are injected. `DefaultAzureCredential` falls back to managed identity using the kubelet identity from `/etc/kubernetes/azure.json`.
+
+> **Important:** On AKS clusters with workload identity **enabled**, the webhook will inject partial env vars even without the `client-id` annotation (it injects `AZURE_TENANT_ID` and `AZURE_FEDERATED_TOKEN_FILE` but not `AZURE_CLIENT_ID`). This causes `DefaultAzureCredential` to attempt workload identity authentication with the kubelet identity, which will fail because the kubelet identity does not have a federated credential. **If your cluster has workload identity enabled, you must complete the setup below** for dynamic provisioning to work.
+
+## Prerequisites
+
+- An AKS cluster with [OIDC issuer](https://learn.microsoft.com/en-us/azure/aks/use-oidc-issuer) and [workload identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster) enabled
+- A user-assigned managed identity in Azure
+- A federated identity credential linking the Kubernetes service account to the managed identity
+
+## Setup
+
+### 1. Enable Workload Identity on Your AKS Cluster
+
+If not already enabled:
+
+```bash
+az aks update \
+  --resource-group <RESOURCE_GROUP> \
+  --name <CLUSTER_NAME> \
+  --enable-oidc-issuer \
+  --enable-workload-identity
+```
+
+### 2. Create a User-Assigned Managed Identity
+
+```bash
+az identity create \
+  --name <IDENTITY_NAME> \
+  --resource-group <RESOURCE_GROUP> \
+  --location <LOCATION>
+
+export USER_ASSIGNED_CLIENT_ID="$(az identity show \
+  --resource-group <RESOURCE_GROUP> \
+  --name <IDENTITY_NAME> \
+  --query 'clientId' -o tsv)"
+```
+
+### 3. Assign Required Roles
+
+The managed identity needs permissions to manage AMLFS resources. See [driver-parameters.md](driver-parameters.md) for the full list of required permissions.
+
+At minimum, assign:
+
+```bash
+# Contributor on the resource group where AMLFS clusters will be created
+az role assignment create \
+  --assignee "${USER_ASSIGNED_CLIENT_ID}" \
+  --role "Contributor" \
+  --scope "/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP>"
+
+# Network Contributor on the virtual network
+az role assignment create \
+  --assignee "${USER_ASSIGNED_CLIENT_ID}" \
+  --role "Network Contributor" \
+  --scope "/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<VNET_RESOURCE_GROUP>/providers/Microsoft.Network/virtualNetworks/<VNET_NAME>"
+```
+
+### 4. Create a Federated Identity Credential
+
+Get the OIDC issuer URL:
+
+```bash
+export AKS_OIDC_ISSUER="$(az aks show \
+  --name <CLUSTER_NAME> \
+  --resource-group <RESOURCE_GROUP> \
+  --query "oidcIssuerProfile.issuerUrl" -o tsv)"
+```
+
+Create the federated credential for the controller service account:
+
+```bash
+az identity federated-credential create \
+  --name "azurelustre-csi-controller" \
+  --identity-name <IDENTITY_NAME> \
+  --resource-group <RESOURCE_GROUP> \
+  --issuer "${AKS_OIDC_ISSUER}" \
+  --subject "system:serviceaccount:kube-system:csi-azurelustre-controller-sa" \
+  --audience api://AzureADTokenExchange
+```
+
+### 5. Annotate the Service Account
+
+The CSI driver's controller service account must be annotated with the managed identity's client ID:
+
+```bash
+kubectl annotate serviceaccount csi-azurelustre-controller-sa \
+  -n kube-system \
+  azure.workload.identity/client-id="${USER_ASSIGNED_CLIENT_ID}"
+```
+
+The service account already has the `azure.workload.identity/use: "true"` label in the default deployment manifests, which enables the AKS workload identity webhook to inject the required environment variables and projected token volume.
+
+> **Note:** The node service account (`csi-azurelustre-node-sa`) also carries the workload identity label for consistency, but only the **controller** needs workload identity configuration. The node plugin performs kernel Lustre mounts over the network and does not make Azure API calls. You do not need to create a federated credential or annotation for the node service account.
+
+## How It Works
+
+The deploy manifests include the `azure.workload.identity/use: "true"` label on both the service accounts and the pod templates. On AKS clusters with workload identity enabled, the mutating admission webhook detects this label and injects into pods:
+
+- `AZURE_TENANT_ID` — the tenant ID of the cluster
+- `AZURE_CLIENT_ID` — the client ID from the service account's `azure.workload.identity/client-id` annotation
+- `AZURE_FEDERATED_TOKEN_FILE` — path to a projected service account token volume
+- `AZURE_AUTHORITY_HOST` — the Entra ID authority URL
+
+`DefaultAzureCredential` detects these environment variables and uses `WorkloadIdentityCredential` to exchange the projected service account token for an Entra ID access token via the federated identity credential.
+
+> **Note:** The webhook only injects `AZURE_CLIENT_ID` when the service account has the `azure.workload.identity/client-id` annotation. Without this annotation, the webhook injects the other env vars but not the client ID, which causes authentication to fail. This is why Step 5 (annotating the service account) is required.
+
+## Clusters Without Workload Identity
+
+On AKS clusters created without `--enable-workload-identity`, or on non-AKS Kubernetes clusters, the workload identity webhook is not installed. The `azure.workload.identity/use: "true"` labels on the pod templates have no effect — no env vars or projected volumes are injected. `DefaultAzureCredential` uses the managed identity from `/etc/kubernetes/azure.json` as it always has.
+
+No additional configuration is needed for these clusters — dynamic provisioning works via the kubelet managed identity as documented in [driver-parameters.md](driver-parameters.md).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds Workload Identity support to the Azure Lustre CSI driver. This is a prerequisite for AKS extension onboarding per the [Partner Onboarding Security Requirements](https://msazure.visualstudio.com/One/_wiki/wikis/One.wiki/102775/Partner-Onboarding-Process), which require all extensions to support workload identity.

### Changes

**Credential handling** (`pkg/azurelustre/azurelustre.go`):
- Add `newAzureCredential()` that creates `WorkloadIdentityCredential` when `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_FEDERATED_TOKEN_FILE` env vars are present (injected by the AKS workload identity webhook)
- Falls back to `DefaultAzureCredential` when workload identity is not configured, preserving backward compatibility
- Adds logging to indicate which credential type is being used

**Deploy manifests**:
- Add `azure.workload.identity/use: "true"` label to controller and node service accounts with commented annotation placeholders for `client-id`/`tenant-id`
- Add `azure.workload.identity/use: "true"` label to controller Deployment and node DaemonSet pod templates (the webhook matches on pod labels)
- Add pod-level `seccompProfile: RuntimeDefault` (PSS Baseline requirement)
- Add `capabilities.drop: [ALL]` to sidecar containers (csi-provisioner, liveness-probe, node-driver-registrar)
- Node `azurelustre` container retains `privileged: true` for kernel module loading and mount operations (same pattern as blob-csi-driver)

**Documentation**:
- New `docs/workload-identity.md` with prerequisites, step-by-step setup guide
- Updated `docs/driver-parameters.md` to reference workload identity docs

**Which issue(s) this PR fixes**:
Fixes AB#35653648

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:

### Testing performed

**Local/CI:**
- `make unit-test`: ✅ 89.3% coverage, all passing (3 new tests for `newAzureCredential()`)
- `make sanity-test-local`: ✅ 30/30 passed
- `make azurelustre`: ✅ Binary builds

**Cluster validation** (MLT-10, canadacentral, custom image from branch):
- ✅ Static mount with PSS changes — Lustre mounted, data read/write works
- ✅ DefaultAzureCredential fallback — controller ran with managed identity when WI not annotated
- ✅ Workload identity injection — all 3 env vars + projected token volume injected by webhook
- ✅ Driver log confirmed: `using workload identity for authentication (tenantID: ..., clientID: ...)`
- ✅ **Dynamic provisioning via WI** — AMLFS cluster (4 TiB) created through ARM API calls authenticated via federated service account token. PVC bound successfully.

### Design decisions
- Workload identity is **optional** — falls back to `DefaultAzureCredential` (managed identity from `/etc/kubernetes/azure.json`) when not configured
- Azure auth is only needed for **dynamic provisioning** (ARM API calls). Static provisioning uses kernel Lustre mounts and does not require Azure authentication
- The `/etc/kubernetes/azure.json` hostPath mount is still needed for subscription ID, resource group, location context
- Follows patterns from `kubernetes-sigs/blob-csi-driver`

**Release note**:
```
feat: Add Workload Identity support for Azure authentication, enabling federated service account token-based auth as an alternative to managed identity. Required for AKS extension onboarding.
```
