### PR TITLE
feat: allow volume mounting of the CSI driver entrypoint script

### DIFF
--- a/deploy/csi-azurelustre-node-jammy.yaml
+++ b/deploy/csi-azurelustre-node-jammy.yaml
@@ -161,6 +161,9 @@ spec:
               name: host-dev
             - mountPath: /etc/host-os-release
               name: host-os-release
+            - mountPath: /app/custom-entrypoint
+              name: custom-entrypoint
+              readOnly: true
           resources:
             limits:
               cpu: 1
@@ -193,3 +196,8 @@ spec:
             path: /etc/os-release
             type: File
           name: host-os-release
+        - name: custom-entrypoint
+          configMap:
+            name: csi-azurelustre-entrypoint
+            defaultMode: 0755
+            optional: true

--- a/deploy/csi-azurelustre-node-noble.yaml
+++ b/deploy/csi-azurelustre-node-noble.yaml
@@ -157,6 +157,9 @@ spec:
               name: host-dev
             - mountPath: /etc/host-os-release
               name: host-os-release
+            - mountPath: /app/custom-entrypoint
+              name: custom-entrypoint
+              readOnly: true
           resources:
             limits:
               cpu: 1
@@ -189,3 +192,8 @@ spec:
             path: /etc/os-release
             type: File
           name: host-os-release
+        - name: custom-entrypoint
+          configMap:
+            name: csi-azurelustre-entrypoint
+            defaultMode: 0755
+            optional: true

--- a/deploy/install-driver.sh
+++ b/deploy/install-driver.sh
@@ -15,21 +15,51 @@
 # limitations under the License.
 set -euo pipefail
 
+CONFIGMAP_NAME="csi-azurelustre-entrypoint"
+
 function usage {
-    echo "Usage: $0 [branch|local|url]"
+    echo "Usage: $0 [--custom-entrypoint <file>] [branch|local|url]"
     echo
     echo "branch: The branch from which to install the Azure Lustre CSI Driver to install. Default is 'main'."
     echo "local: Deploy out of local filesystem."
+    echo
+    echo "Options:"
+    echo "  --custom-entrypoint <file>  Use a custom entrypoint script via ConfigMap instead of the"
+    echo "                              built-in entrypoint. The file will be mounted into the CSI driver"
+    echo "                              containers. Without this flag, the built-in entrypoint is used."
     echo
     echo "Example:"
     echo "$0 # install from remote main"
     echo "$0 main # install from remote branch or reference"
     echo "$0 local # install from locally checked out branch"
     echo "$0 https://raw.githubusercontent.com/csmuell/azurelustre-csi-driver/main # install from given remote repository/branch"
+    echo "$0 --custom-entrypoint ./my-entrypoint.sh local # install with custom entrypoint"
     exit 1
 }
 
-if [[ "$#" -gt 1 || ("$#" -gt 0 && "$1" == "--help") ]]; then
+custom_entrypoint=""
+
+# Parse --custom-entrypoint flag (must come before positional args)
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --custom-entrypoint)
+      if [[ "$#" -lt 2 ]]; then
+        echo "Error: --custom-entrypoint requires a file path argument."
+        usage
+      fi
+      custom_entrypoint="$2"
+      shift 2
+      ;;
+    --help)
+      usage
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ "$#" -gt 1 ]]; then
   usage
 fi
 
@@ -62,6 +92,25 @@ fi
 echo
 echo "Installing Azure Lustre CSI Driver branch: $branch, repo: $repo ..."
 
+# Handle custom entrypoint ConfigMap
+configmap_changed="false"
+if [[ -n "${custom_entrypoint}" ]]; then
+  if [[ ! -f "${custom_entrypoint}" ]]; then
+    echo "Error: Custom entrypoint file not found: ${custom_entrypoint}"
+    exit 1
+  fi
+  echo "Creating ConfigMap '${CONFIGMAP_NAME}' from custom entrypoint: ${custom_entrypoint}"
+  kubectl create configmap "${CONFIGMAP_NAME}" \
+    --from-file=entrypoint.sh="${custom_entrypoint}" \
+    -n kube-system --dry-run=client -o yaml | kubectl apply -f - | grep -q "configured\|created" && configmap_changed="true"
+else
+  # Clean up any previously created custom entrypoint ConfigMap
+  if kubectl get configmap "${CONFIGMAP_NAME}" -n kube-system &>/dev/null; then
+    kubectl delete configmap "${CONFIGMAP_NAME}" -n kube-system
+    configmap_changed="true"
+  fi
+fi
+
 kubectl delete -n kube-system daemonset csi-azurelustre-node --ignore-not-found
 
 kubectl apply -f "$repo/rbac-csi-azurelustre-controller.yaml"
@@ -70,6 +119,15 @@ kubectl apply -f "$repo/csi-azurelustre-driver.yaml"
 kubectl apply -f "$repo/csi-azurelustre-controller.yaml"
 kubectl apply -f "$repo/csi-azurelustre-node-jammy.yaml"
 kubectl apply -f "$repo/csi-azurelustre-node-noble.yaml"
+
+# Restart node DaemonSet pods only if the ConfigMap state changed.
+# The custom entrypoint ConfigMap is only mounted into node DaemonSets,
+# not the controller, so only node pods need restarting.
+if [[ "${configmap_changed}" == "true" ]]; then
+  echo "Custom entrypoint configuration changed, restarting node pods..."
+  kubectl rollout restart daemonset csi-azurelustre-node-jammy -n kube-system
+  kubectl rollout restart daemonset csi-azurelustre-node-noble -n kube-system
+fi
 
 kubectl rollout status deployment csi-azurelustre-controller -nkube-system --timeout=300s
 kubectl rollout status daemonset csi-azurelustre-node-jammy -nkube-system --timeout=1800s

--- a/deploy/uninstall-driver.sh
+++ b/deploy/uninstall-driver.sh
@@ -29,4 +29,5 @@ kubectl delete -f $repo/csi-azurelustre-node-noble.yaml --ignore-not-found
 kubectl delete -f $repo/csi-azurelustre-driver.yaml --ignore-not-found
 kubectl delete -f $repo/rbac-csi-azurelustre-controller.yaml --ignore-not-found
 kubectl delete -f $repo/rbac-csi-azurelustre-node.yaml --ignore-not-found
+kubectl delete configmap csi-azurelustre-entrypoint -n kube-system --ignore-not-found
 echo 'Uninstalled Azure Lustre CSI driver successfully.'

--- a/docs/install-csi-driver.md
+++ b/docs/install-csi-driver.md
@@ -104,3 +104,39 @@ The startup taint functionality is enabled by default but can be configured duri
 - **Disable Taint Removal**: To disable, set `--remove-not-ready-taint=false` in the driver deployment
 
 For most AKS users, the default behavior provides optimal pod scheduling and should not be changed
+
+## Custom Entrypoint (Advanced)
+
+The CSI driver supports overriding the built-in entrypoint script via a Kubernetes ConfigMap. This is intended as a **troubleshooting/debugging feature** for use when suggested by Microsoft support, or for customers with custom initialization requirements (e.g., non-standard networking setups).
+
+### How It Works
+
+The container uses a wrapper script (`start.sh`) that checks for a custom entrypoint at `/app/custom-entrypoint/entrypoint.sh`. If found, it runs the custom version; otherwise it falls back to the built-in entrypoint. The custom entrypoint is mounted from an optional ConfigMap (`csi-azurelustre-entrypoint`) into the **node DaemonSet pods only** — the controller deployment is not affected.
+
+### Installing with a Custom Entrypoint
+
+Pass `--custom-entrypoint <file>` to the install script:
+
+```shell
+./deploy/install-driver.sh --custom-entrypoint ./my-entrypoint.sh local
+```
+
+This creates a ConfigMap from the provided file and restarts the node DaemonSet pods to use it.
+
+### Reverting to the Built-in Entrypoint
+
+Run the install script without the `--custom-entrypoint` flag:
+
+```shell
+./deploy/install-driver.sh local
+```
+
+This deletes the ConfigMap and restarts the node pods to use the built-in entrypoint. **The custom entrypoint is not sticky** — each install must explicitly request it.
+
+### Important Notes
+
+- The custom entrypoint replaces the **entire** built-in entrypoint, including Lustre client installation logic. Your custom script is responsible for any required setup before launching the CSI driver binary.
+- A good starting point for a custom entrypoint is the built-in script at `pkg/azurelustreplugin/entrypoint.sh`.
+- **Security note:** the custom entrypoint is stored in the `csi-azurelustre-entrypoint` ConfigMap in `kube-system` and is executed by a privileged container. Treat this as a code-injection path: tightly restrict RBAC for creating or updating this ConfigMap, and only use custom entrypoints in trusted/admin scenarios.
+- If you edit the ConfigMap directly (e.g., `kubectl edit configmap csi-azurelustre-entrypoint -n kube-system`), you must manually restart the node DaemonSets for changes to take effect: `kubectl rollout restart daemonset csi-azurelustre-node-jammy csi-azurelustre-node-noble -n kube-system`
+- The uninstall script automatically cleans up the ConfigMap if it exists.

--- a/pkg/azurelustreplugin/Dockerfile
+++ b/pkg/azurelustreplugin/Dockerfile
@@ -17,9 +17,10 @@ FROM ${srcImage}
 
 COPY "./_output/azurelustreplugin" "/app/azurelustreplugin"
 COPY "./pkg/azurelustreplugin/entrypoint.sh" "/app/entrypoint.sh"
+COPY "./pkg/azurelustreplugin/start.sh" "/app/start.sh"
 COPY "./pkg/azurelustreplugin/readinessProbe.sh" "/app/readinessProbe.sh"
 
-RUN chmod +x "/app/entrypoint.sh" && chmod +x "/app/readinessProbe.sh"
+RUN chmod +x "/app/azurelustreplugin" && chmod +x "/app/entrypoint.sh" && chmod +x "/app/start.sh" && chmod +x "/app/readinessProbe.sh"
 
 RUN apt-get update && \
   apt-get upgrade -y && \
@@ -39,4 +40,4 @@ WORKDIR "/app"
 LABEL maintainers="dabradley;t-mialve"
 LABEL description="Azure Lustre CSI driver"
 
-ENTRYPOINT ["/app/entrypoint.sh", "/app/azurelustreplugin"]
+ENTRYPOINT ["/app/start.sh", "/app/azurelustreplugin"]

--- a/pkg/azurelustreplugin/start.sh
+++ b/pkg/azurelustreplugin/start.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wrapper script that checks for a custom entrypoint mounted via ConfigMap.
+# If a custom entrypoint exists at /app/custom-entrypoint/entrypoint.sh,
+# it will be used instead of the built-in /app/entrypoint.sh.
+
+CUSTOM_ENTRYPOINT="/app/custom-entrypoint/entrypoint.sh"
+
+if [ -x "${CUSTOM_ENTRYPOINT}" ]; then
+    echo "$(date -u) Using custom entrypoint: ${CUSTOM_ENTRYPOINT}"
+    exec "${CUSTOM_ENTRYPOINT}" "$@"
+fi
+
+exec /app/entrypoint.sh "$@"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds support for overriding the built-in `entrypoint.sh` via a Kubernetes ConfigMap, enabling entrypoint changes without rebuilding the Docker image. This is useful for troubleshooting customer networking/installation issues and supporting custom initialization requirements (e.g. Nvidia).

A `start.sh` wrapper script checks for a custom entrypoint at `/app/custom-entrypoint/entrypoint.sh` (mounted from an optional ConfigMap). If found, it runs the custom version; otherwise it falls back to the built-in entrypoint. The install script gets a `--custom-entrypoint <file>` flag to create/delete the ConfigMap.

**Which issue(s) this PR fixes**:

AB#34599328

**Requirements**:
- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] includes documentation
- [ ] adds unit tests
- [x] tested upgrade from previous version

**Special notes for your reviewer**:

Tested on AKS (Avere_ManagedLustre_CSISmoke_MLT10_dev, canadacentral, Standard_D2s_v3, Ubuntu 22.04 jammy nodes):

| Test | Result |
|------|--------|
| Default install (no flag) | ✅ No ConfigMap, built-in entrypoint used |
| Custom entrypoint (`--custom-entrypoint`) | ✅ ConfigMap created, `start.sh` dispatched to custom, marker in logs |
| Switch custom → default (re-install without flag) | ✅ ConfigMap deleted, pods restarted, built-in restored |
| Uninstall cleanup | ✅ ConfigMap deleted with all resources |

Key finding during testing: `kubectl apply` alone does not restart pods when only the ConfigMap is created/deleted (the pod spec is unchanged). Added `kubectl rollout restart` to the install script to handle this.

**Release note**:
```
Add --custom-entrypoint flag to install-driver.sh for overriding the CSI driver entrypoint script via ConfigMap without rebuilding the Docker image.
```