### PR TITLE
feat: update Lustre client to 2.15.8-34-gc0f2040

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Starting with v0.4.0, the driver ships separate images per Ubuntu distribution: 
 
 | Driver version | Image | Supported k8s version | Lustre client version |
 | -------------- | ----- | --------------------- | --------------------- |
-| main branch | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-noble | 1.21+ | 2.15.7 |
+| main branch | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-noble | 1.21+ | 2.15.7 (jammy) / 2.16.1 (noble) |
+| development branch | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:latest-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:latest-noble | 1.21+ | 2.15.8 (jammy) / 2.16.1 (noble) |
 | v0.4.0 | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-noble | 1.21+ | 2.15.7 |
 | v0.3.1 | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.3.1 | 1.21+ | 2.15.7 |
 | v0.3.0 | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.3.0 | 1.21+ | 2.15.5 |

--- a/deploy/csi-azurelustre-node-jammy.yaml
+++ b/deploy/csi-azurelustre-node-jammy.yaml
@@ -139,9 +139,9 @@ spec:
             - name: AZURELUSTRE_CSI_INSTALL_LUSTRE_CLIENT
               value: "yes"
             - name: LUSTRE_VERSION
-              value: "2.15.7"
+              value: "2.15.8"
             - name: CLIENT_SHA_SUFFIX
-              value: "33-g79ddf99"
+              value: "34-gc0f2040"
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

Updates the default Lustre client version from 2.15.7 to 2.15.8 in the CSI driver.

### Changes

| Field | Old | New |
|---|---|---|
| LUSTRE_VERSION | `2.15.7` | `2.15.8` |
| CLIENT_SHA_SUFFIX | `33-g79ddf99` | `34-gc0f2040` |

### Files changed

1. `deploy/csi-azurelustre-node.yaml` — environment variables
2. `pkg/azurelustreplugin/entrypoint.sh` — default values
3. `README.md` — version matrix (added development row)

## Which issue(s) this PR fixes

AB#37369746

## Special notes for your reviewer

The 2.15.8 kmod packages must be published to PMC prod before this can be merged and tested on a live AKS cluster.

```release-note
Update Lustre client version to 2.15.8-34-gc0f2040
```