### PR TITLE
Honor stderrthreshold when logtostderr is enabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	k8s.io/api v0.32.11
 	k8s.io/apimachinery v0.32.11
 	k8s.io/client-go v1.5.2
-	k8s.io/klog/v2 v2.130.1
+	k8s.io/klog/v2 v2.140.0
 	k8s.io/kubernetes v1.32.11
 	k8s.io/mount-utils v0.32.11
 	k8s.io/utils v0.0.0-20250321185631-1f6e0b77f77e

--- a/go.sum
+++ b/go.sum
@@ -371,8 +371,8 @@ k8s.io/controller-manager v0.32.11 h1:q+VCJJpNA8/m+4oy9c/ia6x9UgaV3dU3bDOQ4OqGOH
 k8s.io/controller-manager v0.32.11/go.mod h1:RbO7vM7//CP2/0ruVYcaf2mVX78ymUKhEVM9i6hzguc=
 k8s.io/csi-translation-lib v0.32.11 h1:rR9QmrOpyWHaCtFMs9YNNWLH9LM+DFrhZBrTZebKdBc=
 k8s.io/csi-translation-lib v0.32.11/go.mod h1:n6E9/p6dykOq46IDgKFaLH3Zz7iJdukwgBrbUidJ0os=
-k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
-k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
+k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
+k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f h1:GA7//TjRY9yWGy1poLzYYJJ4JRdzg3+O6e8I+e+8T5Y=
 k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f/go.mod h1:R/HEjbvWI0qdfb8viZUeVZm0X6IZnxAydC7YU42CMw4=
 k8s.io/kubernetes v1.32.11 h1:vGU5kf3OD2/Pu/OAOyPld7gHlS1gmeRth54PWxcRVMM=

--- a/pkg/azurelustreplugin/main.go
+++ b/pkg/azurelustreplugin/main.go
@@ -38,16 +38,7 @@ var (
 
 func main() {
 	klog.InitFlags(nil)
-	err := flag.Set("logtostderr", "true")
-	if err != nil {
-		klog.Fatalln(err)
-	}
-	err = flag.Set("legacy_stderr_threshold_behavior", "false")
-	if err != nil {
-		klog.Fatalln(err)
-	}
-	err = flag.Set("stderrthreshold", "INFO")
-	if err != nil {
+	if err := initKlogFlags(); err != nil {
 		klog.Fatalln(err)
 	}
 	flag.Parse()
@@ -82,4 +73,21 @@ func handle() {
 		klog.Fatalln("Failed to initialize Azure Lustre CSI driver")
 	}
 	driver.Run(*endpoint, false)
+}
+
+// initKlogFlags configures klog flags for the CSI driver:
+//   - logtostderr=true: log to stderr instead of files
+//   - legacy_stderr_threshold_behavior=false: honor stderrthreshold even when logtostderr=true
+//   - stderrthreshold=INFO: preserve current behavior where all severity levels are logged
+func initKlogFlags() error {
+	if err := flag.Set("logtostderr", "true"); err != nil {
+		return fmt.Errorf("failed to set logtostderr: %w", err)
+	}
+	if err := flag.Set("legacy_stderr_threshold_behavior", "false"); err != nil {
+		return fmt.Errorf("failed to set legacy_stderr_threshold_behavior: %w", err)
+	}
+	if err := flag.Set("stderrthreshold", "INFO"); err != nil {
+		return fmt.Errorf("failed to set stderrthreshold: %w", err)
+	}
+	return nil
 }

--- a/pkg/azurelustreplugin/main.go
+++ b/pkg/azurelustreplugin/main.go
@@ -42,6 +42,14 @@ func main() {
 	if err != nil {
 		klog.Fatalln(err)
 	}
+	err = flag.Set("legacy_stderr_threshold_behavior", "false")
+	if err != nil {
+		klog.Fatalln(err)
+	}
+	err = flag.Set("stderrthreshold", "INFO")
+	if err != nil {
+		klog.Fatalln(err)
+	}
 	flag.Parse()
 	if *version {
 		info, err := azurelustre.GetVersionYAML(*driverName)

--- a/pkg/azurelustreplugin/main_test.go
+++ b/pkg/azurelustreplugin/main_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+func TestInitKlogFlags(t *testing.T) {
+	klog.InitFlags(nil)
+
+	err := initKlogFlags()
+	if err != nil {
+		t.Fatalf("initKlogFlags() returned unexpected error: %v", err)
+	}
+
+	// Verify logtostderr is set to true
+	f := flag.Lookup("logtostderr")
+	if f == nil {
+		t.Fatal("logtostderr flag not found")
+	}
+	if f.Value.String() != "true" {
+		t.Errorf("logtostderr = %q, want %q", f.Value.String(), "true")
+	}
+
+	// Verify legacy_stderr_threshold_behavior is set to false
+	f = flag.Lookup("legacy_stderr_threshold_behavior")
+	if f == nil {
+		t.Fatal("legacy_stderr_threshold_behavior flag not found")
+	}
+	if f.Value.String() != "false" {
+		t.Errorf("legacy_stderr_threshold_behavior = %q, want %q", f.Value.String(), "false")
+	}
+
+	// Verify stderrthreshold is set to INFO (severity 0)
+	f = flag.Lookup("stderrthreshold")
+	if f == nil {
+		t.Fatal("stderrthreshold flag not found")
+	}
+	// klog's severityValue.String() returns the numeric value;
+	// INFO = severity 0
+	if f.Value.String() != "0" {
+		t.Errorf("stderrthreshold = %q, want %q (INFO)", f.Value.String(), "0")
+	}
+}

--- a/vendor/k8s.io/klog/v2/README.md
+++ b/vendor/k8s.io/klog/v2/README.md
@@ -48,8 +48,6 @@ How to use klog
 - For more logging conventions (See [Logging Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md))
 - See our documentation on [pkg.go.dev/k8s.io](https://pkg.go.dev/k8s.io/klog).
 
-**NOTE**: please use the newer go versions that support semantic import versioning in modules, ideally go 1.11.4 or greater.
-
 ### Coexisting with klog/v2
 
 See [this example](examples/coexist_klog_v1_and_v2/) to see how to coexist with both klog/v1 and klog/v2.

--- a/vendor/k8s.io/klog/v2/internal/serialize/keyvalues.go
+++ b/vendor/k8s.io/klog/v2/internal/serialize/keyvalues.go
@@ -20,7 +20,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 )
@@ -51,139 +53,157 @@ func WithValues(oldKV, newKV []interface{}) []interface{} {
 	return kv
 }
 
-// MergeKVs deduplicates elements provided in two key/value slices.
-//
-// Keys in each slice are expected to be unique, so duplicates can only occur
-// when the first and second slice contain the same key. When that happens, the
-// key/value pair from the second slice is used. The first slice must be well-formed
-// (= even key/value pairs). The second one may have a missing value, in which
-// case the special "missing value" is added to the result.
-func MergeKVs(first, second []interface{}) []interface{} {
-	maxLength := len(first) + (len(second)+1)/2*2
-	if maxLength == 0 {
-		// Nothing to do at all.
-		return nil
-	}
-
-	if len(first) == 0 && len(second)%2 == 0 {
-		// Nothing to be overridden, second slice is well-formed
-		// and can be used directly.
-		return second
-	}
-
-	// Determine which keys are in the second slice so that we can skip
-	// them when iterating over the first one. The code intentionally
-	// favors performance over completeness: we assume that keys are string
-	// constants and thus compare equal when the string values are equal. A
-	// string constant being overridden by, for example, a fmt.Stringer is
-	// not handled.
-	overrides := map[interface{}]bool{}
-	for i := 0; i < len(second); i += 2 {
-		overrides[second[i]] = true
-	}
-	merged := make([]interface{}, 0, maxLength)
-	for i := 0; i+1 < len(first); i += 2 {
-		key := first[i]
-		if overrides[key] {
-			continue
-		}
-		merged = append(merged, key, first[i+1])
-	}
-	merged = append(merged, second...)
-	if len(merged)%2 != 0 {
-		merged = append(merged, missingValue)
-	}
-	return merged
-}
-
 type Formatter struct {
 	AnyToStringHook AnyToStringFunc
 }
 
 type AnyToStringFunc func(v interface{}) string
 
-// MergeKVsInto is a variant of MergeKVs which directly formats the key/value
-// pairs into a buffer.
-func (f Formatter) MergeAndFormatKVs(b *bytes.Buffer, first, second []interface{}) {
-	if len(first) == 0 && len(second) == 0 {
-		// Nothing to do at all.
-		return
-	}
-
-	if len(first) == 0 && len(second)%2 == 0 {
-		// Nothing to be overridden, second slice is well-formed
-		// and can be used directly.
-		for i := 0; i < len(second); i += 2 {
-			f.KVFormat(b, second[i], second[i+1])
-		}
-		return
-	}
-
-	// Determine which keys are in the second slice so that we can skip
-	// them when iterating over the first one. The code intentionally
-	// favors performance over completeness: we assume that keys are string
-	// constants and thus compare equal when the string values are equal. A
-	// string constant being overridden by, for example, a fmt.Stringer is
-	// not handled.
-	overrides := map[interface{}]bool{}
-	for i := 0; i < len(second); i += 2 {
-		overrides[second[i]] = true
-	}
-	for i := 0; i < len(first); i += 2 {
-		key := first[i]
-		if overrides[key] {
-			continue
-		}
-		f.KVFormat(b, key, first[i+1])
-	}
-	// Round down.
-	l := len(second)
-	l = l / 2 * 2
-	for i := 1; i < l; i += 2 {
-		f.KVFormat(b, second[i-1], second[i])
-	}
-	if len(second)%2 == 1 {
-		f.KVFormat(b, second[len(second)-1], missingValue)
-	}
-}
-
-func MergeAndFormatKVs(b *bytes.Buffer, first, second []interface{}) {
-	Formatter{}.MergeAndFormatKVs(b, first, second)
-}
-
 const missingValue = "(MISSING)"
 
-// KVListFormat serializes all key/value pairs into the provided buffer.
-// A space gets inserted before the first pair and between each pair.
-func (f Formatter) KVListFormat(b *bytes.Buffer, keysAndValues ...interface{}) {
-	for i := 0; i < len(keysAndValues); i += 2 {
-		var v interface{}
-		k := keysAndValues[i]
-		if i+1 < len(keysAndValues) {
-			v = keysAndValues[i+1]
-		} else {
-			v = missingValue
+func FormatKVs(b *bytes.Buffer, kvs ...[]interface{}) {
+	Formatter{}.FormatKVs(b, kvs...)
+}
+
+// FormatKVs formats all key/value pairs such that the output contains no
+// duplicates ("last one wins").
+func (f Formatter) FormatKVs(b *bytes.Buffer, kvs ...[]interface{}) {
+	// De-duplication is done by optimistically formatting all key value
+	// pairs and then cutting out the output of those key/value pairs which
+	// got overwritten later.
+	//
+	// In the common case of no duplicates, the only overhead is tracking
+	// previous keys. This uses a slice with a simple linear search because
+	// the number of entries is typically so low that allocating a map or
+	// keeping a sorted slice with binary search aren't justified.
+	//
+	// Using a fixed size here makes the Go compiler use the stack as
+	// initial backing store for the slice, which is crucial for
+	// performance.
+	existing := make([]obsoleteKV, 0, 32)
+	obsolete := make([]interval, 0, 32) // Sorted by start index.
+	for _, keysAndValues := range kvs {
+		for i := 0; i < len(keysAndValues); i += 2 {
+			var v interface{}
+			k := keysAndValues[i]
+			if i+1 < len(keysAndValues) {
+				v = keysAndValues[i+1]
+			} else {
+				v = missingValue
+			}
+			var e obsoleteKV
+			e.start = b.Len()
+			e.key = f.KVFormat(b, k, v)
+			e.end = b.Len()
+			i := findObsoleteEntry(existing, e.key)
+			if i >= 0 {
+				data := b.Bytes()
+				if bytes.Compare(data[existing[i].start:existing[i].end], data[e.start:e.end]) == 0 {
+					// The new entry gets obsoleted because it's identical.
+					// This has the advantage that key/value pairs from
+					// a WithValues call always come first, even if the same
+					// pair gets added again later. This makes different log
+					// entries more consistent.
+					//
+					// The new entry has a higher start index and thus can be appended.
+					obsolete = append(obsolete, e.interval)
+				} else {
+					// The old entry gets obsoleted because it's value is different.
+					//
+					// Sort order is not guaranteed, we have to insert at the right place.
+					index, _ := slices.BinarySearchFunc(obsolete, existing[i].interval, func(a, b interval) int { return a.start - b.start })
+					obsolete = slices.Insert(obsolete, index, existing[i].interval)
+					existing[i].interval = e.interval
+				}
+			} else {
+				// Instead of appending at the end and doing a
+				// linear search in findEntry, we could keep
+				// the slice sorted by key and do a binary search.
+				//
+				// Above:
+				//    i, ok := slices.BinarySearchFunc(existing, e, func(a, b entry) int { return strings.Compare(a.key, b.key) })
+				// Here:
+				//    existing = slices.Insert(existing, i, e)
+				//
+				// But that adds a dependency on the slices package
+				// and made performance slightly worse, presumably
+				// because the cost of shifting entries around
+				// did not pay of with faster lookups.
+				existing = append(existing, e)
+			}
 		}
-		f.KVFormat(b, k, v)
+	}
+
+	// If we need to remove some obsolete key/value pairs then move the memory.
+	if len(obsolete) > 0 {
+		// Potentially the next remaining output (might itself be obsolete).
+		from := obsolete[0].end
+		// Next obsolete entry.
+		nextObsolete := 1
+		// This is the source buffer, before truncation.
+		all := b.Bytes()
+		b.Truncate(obsolete[0].start)
+
+		for nextObsolete < len(obsolete) {
+			if from == obsolete[nextObsolete].start {
+				// Skip also the next obsolete key/value.
+				from = obsolete[nextObsolete].end
+				nextObsolete++
+				continue
+			}
+
+			// Preserve some output. Write uses copy, which
+			// explicitly allows source and destination to overlap.
+			// That could happen here.
+			valid := all[from:obsolete[nextObsolete].start]
+			b.Write(valid)
+			from = obsolete[nextObsolete].end
+			nextObsolete++
+		}
+		// Copy end of buffer.
+		valid := all[from:]
+		b.Write(valid)
 	}
 }
 
-func KVListFormat(b *bytes.Buffer, keysAndValues ...interface{}) {
-	Formatter{}.KVListFormat(b, keysAndValues...)
+type obsoleteKV struct {
+	key string
+	interval
 }
 
-func KVFormat(b *bytes.Buffer, k, v interface{}) {
-	Formatter{}.KVFormat(b, k, v)
+// interval includes the start and excludes the end.
+type interval struct {
+	start int
+	end   int
+}
+
+func findObsoleteEntry(entries []obsoleteKV, key string) int {
+	for i, entry := range entries {
+		if entry.key == key {
+			return i
+		}
+	}
+	return -1
 }
 
 // formatAny is the fallback formatter for a value. It supports a hook (for
 // example, for YAML encoding) and itself uses JSON encoding.
 func (f Formatter) formatAny(b *bytes.Buffer, v interface{}) {
-	b.WriteRune('=')
 	if f.AnyToStringHook != nil {
-		b.WriteString(f.AnyToStringHook(v))
+		str := f.AnyToStringHook(v)
+		if strings.Contains(str, "\n") {
+			// If it's multi-line, then pass it through writeStringValue to get start/end delimiters,
+			// which separates it better from any following key/value pair.
+			writeStringValue(b, str)
+			return
+		}
+		// Otherwise put it directly after the separator, on the same lime,
+		// The assumption is that the hook returns something where start/end are obvious.
+		b.WriteRune('=')
+		b.WriteString(str)
 		return
 	}
+	b.WriteRune('=')
 	formatAsJSON(b, v)
 }
 

--- a/vendor/k8s.io/klog/v2/internal/serialize/keyvalues_no_slog.go
+++ b/vendor/k8s.io/klog/v2/internal/serialize/keyvalues_no_slog.go
@@ -28,7 +28,7 @@ import (
 
 // KVFormat serializes one key/value pair into the provided buffer.
 // A space gets inserted before the pair.
-func (f Formatter) KVFormat(b *bytes.Buffer, k, v interface{}) {
+func (f Formatter) KVFormat(b *bytes.Buffer, k, v interface{}) string {
 	// This is the version without slog support. Must be kept in sync with
 	// the version in keyvalues_slog.go.
 
@@ -37,13 +37,15 @@ func (f Formatter) KVFormat(b *bytes.Buffer, k, v interface{}) {
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments
 	// for the sake of performance. Keys with spaces,
 	// special characters, etc. will break parsing.
+	var key string
 	if sK, ok := k.(string); ok {
 		// Avoid one allocation when the key is a string, which
 		// normally it should be.
-		b.WriteString(sK)
+		key = sK
 	} else {
-		b.WriteString(fmt.Sprintf("%s", k))
+		key = fmt.Sprintf("%s", k)
 	}
+	b.WriteString(key)
 
 	// The type checks are sorted so that more frequently used ones
 	// come first because that is then faster in the common
@@ -94,4 +96,6 @@ func (f Formatter) KVFormat(b *bytes.Buffer, k, v interface{}) {
 	default:
 		f.formatAny(b, v)
 	}
+
+	return key
 }

--- a/vendor/k8s.io/klog/v2/internal/serialize/keyvalues_slog.go
+++ b/vendor/k8s.io/klog/v2/internal/serialize/keyvalues_slog.go
@@ -29,8 +29,8 @@ import (
 )
 
 // KVFormat serializes one key/value pair into the provided buffer.
-// A space gets inserted before the pair.
-func (f Formatter) KVFormat(b *bytes.Buffer, k, v interface{}) {
+// A space gets inserted before the pair. It returns the key.
+func (f Formatter) KVFormat(b *bytes.Buffer, k, v interface{}) string {
 	// This is the version without slog support. Must be kept in sync with
 	// the version in keyvalues_slog.go.
 
@@ -39,13 +39,15 @@ func (f Formatter) KVFormat(b *bytes.Buffer, k, v interface{}) {
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md#name-arguments
 	// for the sake of performance. Keys with spaces,
 	// special characters, etc. will break parsing.
+	var key string
 	if sK, ok := k.(string); ok {
 		// Avoid one allocation when the key is a string, which
 		// normally it should be.
-		b.WriteString(sK)
+		key = sK
 	} else {
-		b.WriteString(fmt.Sprintf("%s", k))
+		key = fmt.Sprintf("%s", k)
 	}
+	b.WriteString(key)
 
 	// The type checks are sorted so that more frequently used ones
 	// come first because that is then faster in the common
@@ -112,6 +114,8 @@ func (f Formatter) KVFormat(b *bytes.Buffer, k, v interface{}) {
 	default:
 		f.formatAny(b, v)
 	}
+
+	return key
 }
 
 // generateJSON has the same preference for plain strings as KVFormat.

--- a/vendor/k8s.io/klog/v2/klog.go
+++ b/vendor/k8s.io/klog/v2/klog.go
@@ -58,15 +58,30 @@
 //
 //		-logtostderr=true
 //			Logs are written to standard error instead of to files.
-//	             This shortcuts most of the usual output routing:
-//	             -alsologtostderr, -stderrthreshold and -log_dir have no
-//	             effect and output redirection at runtime with SetOutput is
-//	             ignored.
+//	             By default, all logs are written regardless of severity
+//	             (legacy behavior). To filter logs by severity when
+//	             -logtostderr=true, set -legacy_stderr_threshold_behavior=false
+//	             and use -stderrthreshold.
+//              With -legacy_stderr_threshold_behavior=true,
+//              -stderrthreshold has no effect.
+//
+//	             The following flags always have no effect:
+//	             -alsologtostderr, -alsologtostderrthreshold, and -log_dir.
+//	             Output redirection at runtime with SetOutput is also ignored.
 //		-alsologtostderr=false
 //			Logs are written to standard error as well as to files.
+//		-alsologtostderrthreshold=INFO
+//			Log events at or above this severity are logged to standard
+//			error when -alsologtostderr=true (no effect when -logtostderr=true).
+//			Default is INFO to maintain backward compatibility.
 //		-stderrthreshold=ERROR
 //			Log events at or above this severity are logged to standard
-//			error as well as to files.
+//			error as well as to files. When -logtostderr=true, this flag
+//			has no effect unless -legacy_stderr_threshold_behavior=false.
+//		-legacy_stderr_threshold_behavior=true
+//			If true, -stderrthreshold is ignored when -logtostderr=true
+//			(legacy behavior). If false, -stderrthreshold is honored even
+//			when -logtostderr=true, allowing severity-based filtering.
 //		-log_dir=""
 //			Log files will be written to this directory instead of the
 //			default temporary directory.
@@ -156,7 +171,7 @@ func (s *severityValue) Set(value string) error {
 		}
 		threshold = severity.Severity(v)
 	}
-	logging.stderrThreshold.set(threshold)
+	s.set(threshold)
 	return nil
 }
 
@@ -409,6 +424,15 @@ var commandLine flag.FlagSet
 
 // init sets up the defaults and creates command line flags.
 func init() {
+	// Initialize severity thresholds
+	logging.stderrThreshold = severityValue{
+		Severity: severity.ErrorLog, // Default stderrThreshold is ERROR.
+	}
+	logging.alsologtostderrthreshold = severityValue{
+		Severity: severity.InfoLog, // Default alsologtostderrthreshold is INFO (to maintain backward compatibility).
+	}
+	logging.setVState(0, nil, false)
+
 	commandLine.StringVar(&logging.logDir, "log_dir", "", "If non-empty, write log files in this directory (no effect when -logtostderr=true)")
 	commandLine.StringVar(&logging.logFile, "log_file", "", "If non-empty, use this log file (no effect when -logtostderr=true)")
 	commandLine.Uint64Var(&logging.logFileMaxSizeMB, "log_file_max_size", 1800,
@@ -416,16 +440,14 @@ func init() {
 			"If the value is 0, the maximum file size is unlimited.")
 	commandLine.BoolVar(&logging.toStderr, "logtostderr", true, "log to standard error instead of files")
 	commandLine.BoolVar(&logging.alsoToStderr, "alsologtostderr", false, "log to standard error as well as files (no effect when -logtostderr=true)")
-	logging.setVState(0, nil, false)
+	commandLine.BoolVar(&logging.legacyStderrThresholdBehavior, "legacy_stderr_threshold_behavior", true, "If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true")
 	commandLine.Var(&logging.verbosity, "v", "number for the log level verbosity")
 	commandLine.BoolVar(&logging.addDirHeader, "add_dir_header", false, "If true, adds the file directory to the header of the log messages")
 	commandLine.BoolVar(&logging.skipHeaders, "skip_headers", false, "If true, avoid header prefixes in the log messages")
 	commandLine.BoolVar(&logging.oneOutput, "one_output", false, "If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)")
 	commandLine.BoolVar(&logging.skipLogHeaders, "skip_log_headers", false, "If true, avoid headers when opening log files (no effect when -logtostderr=true)")
-	logging.stderrThreshold = severityValue{
-		Severity: severity.ErrorLog, // Default stderrThreshold is ERROR.
-	}
-	commandLine.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true)")
+	commandLine.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false)")
+	commandLine.Var(&logging.alsologtostderrthreshold, "alsologtostderrthreshold", "logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)")
 	commandLine.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
 	commandLine.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")
 
@@ -470,11 +492,13 @@ type settings struct {
 	// Boolean flags. Not handled atomically because the flag.Value interface
 	// does not let us avoid the =true, and that shorthand is necessary for
 	// compatibility. TODO: does this matter enough to fix? Seems unlikely.
-	toStderr     bool // The -logtostderr flag.
-	alsoToStderr bool // The -alsologtostderr flag.
+	toStderr                      bool // The -logtostderr flag.
+	alsoToStderr                  bool // The -alsologtostderr flag.
+	legacyStderrThresholdBehavior bool // The -legacy_stderr_threshold_behavior flag.
 
 	// Level flag. Handled atomically.
-	stderrThreshold severityValue // The -stderrthreshold flag.
+	stderrThreshold          severityValue // The -stderrthreshold flag.
+	alsologtostderrthreshold severityValue // The -alsologtostderrthreshold flag.
 
 	// Access to all of the following fields must be protected via a mutex.
 
@@ -809,16 +833,21 @@ func (l *loggingT) infoS(logger *logWriter, filter LogFilter, depth int, msg str
 // printS is called from infoS and errorS if logger is not specified.
 // set log severity by s
 func (l *loggingT) printS(err error, s severity.Severity, depth int, msg string, keysAndValues ...interface{}) {
-	// Only create a new buffer if we don't have one cached.
-	b := buffer.GetBuffer()
 	// The message is always quoted, even if it contains line breaks.
 	// If developers want multi-line output, they should use a small, fixed
 	// message and put the multi-line output into a value.
-	b.WriteString(strconv.Quote(msg))
+	qMsg := make([]byte, 0, 1024)
+	qMsg = strconv.AppendQuote(qMsg, msg)
+
+	// Only create a new buffer if we don't have one cached.
+	b := buffer.GetBuffer()
+	b.Write(qMsg)
+
+	var errKV []interface{}
 	if err != nil {
-		serialize.KVListFormat(&b.Buffer, "err", err)
+		errKV = []interface{}{"err", err}
 	}
-	serialize.KVListFormat(&b.Buffer, keysAndValues...)
+	serialize.FormatKVs(&b.Buffer, errKV, keysAndValues)
 	l.printDepth(s, nil, nil, depth+1, &b.Buffer)
 	// Make the buffer available for reuse.
 	buffer.PutBuffer(b)
@@ -885,9 +914,25 @@ func (l *loggingT) output(s severity.Severity, logger *logWriter, buf *buffer.Bu
 			}
 		}
 	} else if l.toStderr {
-		os.Stderr.Write(data)
+		// When logging to stderr only, check if we should filter by severity.
+		// This is controlled by the legacy_stderr_threshold_behavior flag.
+		if l.legacyStderrThresholdBehavior {
+			// Legacy behavior: always write to stderr, ignore stderrthreshold
+			os.Stderr.Write(data)
+		} else {
+			// New behavior: honor stderrthreshold even when logtostderr=true
+			if s >= l.stderrThreshold.get() {
+				os.Stderr.Write(data)
+			}
+		}
 	} else {
-		if alsoToStderr || l.alsoToStderr || s >= l.stderrThreshold.get() {
+		// Write to stderr if any of these conditions are met:
+		// - alsoToStderr is set (legacy behavior)
+		// - alsologtostderr is set and severity meets alsologtostderrthreshold
+		// - alsologtostderr is not set and severity meets stderrThreshold
+		if alsoToStderr ||
+			(l.alsoToStderr && s >= l.alsologtostderrthreshold.get()) ||
+			(!l.alsoToStderr && s >= l.stderrThreshold.get()) {
 			os.Stderr.Write(data)
 		}
 

--- a/vendor/k8s.io/klog/v2/klogr.go
+++ b/vendor/k8s.io/klog/v2/klogr.go
@@ -53,7 +53,7 @@ func (l *klogger) Init(info logr.RuntimeInfo) {
 }
 
 func (l *klogger) Info(level int, msg string, kvList ...interface{}) {
-	merged := serialize.MergeKVs(l.values, kvList)
+	merged := serialize.WithValues(l.values, kvList)
 	// Skip this function.
 	VDepth(l.callDepth+1, Level(level)).InfoSDepth(l.callDepth+1, msg, merged...)
 }
@@ -63,7 +63,7 @@ func (l *klogger) Enabled(level int) bool {
 }
 
 func (l *klogger) Error(err error, msg string, kvList ...interface{}) {
-	merged := serialize.MergeKVs(l.values, kvList)
+	merged := serialize.WithValues(l.values, kvList)
 	ErrorSDepth(l.callDepth+1, err, msg, merged...)
 }
 

--- a/vendor/k8s.io/klog/v2/klogr_slog.go
+++ b/vendor/k8s.io/klog/v2/klogr_slog.go
@@ -63,12 +63,17 @@ func slogOutput(file string, line int, now time.Time, err error, s severity.Seve
 	}
 
 	// See printS.
+	qMsg := make([]byte, 0, 1024)
+	qMsg = strconv.AppendQuote(qMsg, msg)
+
 	b := buffer.GetBuffer()
-	b.WriteString(strconv.Quote(msg))
+	b.Write(qMsg)
+
+	var errKV []interface{}
 	if err != nil {
-		serialize.KVListFormat(&b.Buffer, "err", err)
+		errKV = []interface{}{"err", err}
 	}
-	serialize.KVListFormat(&b.Buffer, kvList...)
+	serialize.FormatKVs(&b.Buffer, errKV, kvList)
 
 	// See print + header.
 	buf := logging.formatHeader(s, file, line, now)

--- a/vendor/k8s.io/klog/v2/textlogger/options.go
+++ b/vendor/k8s.io/klog/v2/textlogger/options.go
@@ -59,6 +59,7 @@ type configOptions struct {
 	verbosityDefault  int
 	fixedTime         *time.Time
 	unwind            func(int) (string, int)
+	withHeader        bool
 	output            io.Writer
 }
 
@@ -106,6 +107,22 @@ func FixedTime(ts time.Time) ConfigOption {
 	}
 }
 
+// WithHeader controls whether the header (time, source code location, etc.)
+// is included in the output. The default is to include it.
+//
+// This can be useful in combination with redirection to a buffer to
+// turn structured log parameters into a string (see example).
+//
+// # Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func WithHeader(enabled bool) ConfigOption {
+	return func(co *configOptions) {
+		co.withHeader = enabled
+	}
+}
+
 // Backtrace overrides the default mechanism for determining the call site.
 // The callback is invoked with the number of function calls between itself
 // and the call site. It must return the file name and line number. An empty
@@ -131,6 +148,7 @@ func NewConfig(opts ...ConfigOption) *Config {
 			vmoduleFlagName:   "vmodule",
 			verbosityDefault:  0,
 			unwind:            runtimeBacktrace,
+			withHeader:        true,
 			output:            os.Stderr,
 		},
 	}

--- a/vendor/k8s.io/klog/v2/textlogger/textlogger.go
+++ b/vendor/k8s.io/klog/v2/textlogger/textlogger.go
@@ -92,17 +92,23 @@ func (l *tlogger) Error(err error, msg string, kvList ...interface{}) {
 }
 
 func (l *tlogger) print(err error, s severity.Severity, msg string, kvList []interface{}) {
-	// Determine caller.
-	// +1 for this frame, +1 for Info/Error.
-	skip := l.callDepth + 2
-	file, line := l.config.co.unwind(skip)
-	if file == "" {
-		file = "???"
-		line = 1
-	} else if slash := strings.LastIndex(file, "/"); slash >= 0 {
-		file = file[slash+1:]
+	var file string
+	var line int
+	var now time.Time
+	if l.config.co.withHeader {
+		// Determine caller.
+		// +1 for this frame, +1 for Info/Error.
+		skip := l.callDepth + 2
+		file, line = l.config.co.unwind(skip)
+		if file == "" {
+			file = "???"
+			line = 1
+		} else if slash := strings.LastIndex(file, "/"); slash >= 0 {
+			file = file[slash+1:]
+		}
+		now = time.Now()
 	}
-	l.printWithInfos(file, line, time.Now(), err, s, msg, kvList)
+	l.printWithInfos(file, line, now, err, s, msg, kvList)
 }
 
 func runtimeBacktrace(skip int) (string, int) {
@@ -114,24 +120,31 @@ func runtimeBacktrace(skip int) (string, int) {
 }
 
 func (l *tlogger) printWithInfos(file string, line int, now time.Time, err error, s severity.Severity, msg string, kvList []interface{}) {
+	// The message is always quoted, even if it contains line breaks.
+	// If developers want multi-line output, they should use a small, fixed
+	// message and put the multi-line output into a value.
+	qMsg := make([]byte, 0, 1024)
+	qMsg = strconv.AppendQuote(qMsg, msg)
+
 	// Only create a new buffer if we don't have one cached.
 	b := buffer.GetBuffer()
 	defer buffer.PutBuffer(b)
 
-	// Format header.
-	if l.config.co.fixedTime != nil {
-		now = *l.config.co.fixedTime
+	if l.config.co.withHeader {
+		// Format header.
+		if l.config.co.fixedTime != nil {
+			now = *l.config.co.fixedTime
+		}
+		b.FormatHeader(s, file, line, now)
 	}
-	b.FormatHeader(s, file, line, now)
 
-	// The message is always quoted, even if it contains line breaks.
-	// If developers want multi-line output, they should use a small, fixed
-	// message and put the multi-line output into a value.
-	b.WriteString(strconv.Quote(msg))
+	b.Write(qMsg)
+
+	var errKV []interface{}
 	if err != nil {
-		serialize.KVFormat(&b.Buffer, "err", err)
+		errKV = []interface{}{"err", err}
 	}
-	serialize.MergeAndFormatKVs(&b.Buffer, l.values, kvList)
+	serialize.FormatKVs(&b.Buffer, errKV, l.values, kvList)
 	if b.Len() == 0 || b.Bytes()[b.Len()-1] != '\n' {
 		b.WriteByte('\n')
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1092,8 +1092,8 @@ k8s.io/component-helpers/node/util
 # k8s.io/controller-manager v0.32.11 => k8s.io/controller-manager v0.32.11
 ## explicit; go 1.23.0
 k8s.io/controller-manager/pkg/features
-# k8s.io/klog/v2 v2.130.1
-## explicit; go 1.18
+# k8s.io/klog/v2 v2.140.0
+## explicit; go 1.21
 k8s.io/klog/v2
 k8s.io/klog/v2/internal/buffer
 k8s.io/klog/v2/internal/clock


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

When `logtostderr` is set to `true`, klog's `stderrthreshold` flag is ignored due to a legacy default behavior in klog v2. This means all log levels (including INFO and DEBUG) are written to stderr, regardless of the `stderrthreshold` setting.

This PR:
1. Bumps `k8s.io/klog/v2` from v2.130.1 to v2.140.0 to get the fix from [klog PR #432](https://github.com/kubernetes/klog/pull/432)
2. Sets `legacy_stderr_threshold_behavior` to `false` to opt into the corrected behavior where `stderrthreshold` is respected even when `logtostderr=true`

## Which issue(s) this PR fixes

Fixes a logging behavior issue where `stderrthreshold` was silently ignored.

## Special notes for your reviewer

The `legacy_stderr_threshold_behavior` flag was introduced in klog v2.140.0 ([klog PR #432](https://github.com/kubernetes/klog/pull/432)). Setting it to `false` opts into the corrected behavior. The klog bump is a minor version upgrade with no breaking changes.

> This contribution is AI-assisted.