### PR TITLE
feat: auto-inject unique_fsid mount option for Lustre >= 2.15.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Starting with v0.4.0, the driver ships separate images per Ubuntu distribution: 
 
 | Driver version | Image | Supported k8s version | Lustre client version |
 | -------------- | ----- | --------------------- | --------------------- |
-| main branch | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-noble | 1.21+ | 2.15.7 |
+| main branch | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-noble | 1.21+ | 2.15.7 (jammy) / 2.16.1 (noble) |
+| development branch | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:latest-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:latest-noble | 1.21+ | 2.15.8 (jammy) / 2.16.1 (noble) |
 | v0.4.0 | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-noble | 1.21+ | 2.15.7 |
 | v0.3.1 | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.3.1 | 1.21+ | 2.15.7 |
 | v0.3.0 | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.3.0 | 1.21+ | 2.15.5 |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Starting with v0.4.0, the driver ships separate images per Ubuntu distribution: 
 | Driver version | Image | Supported k8s version | Lustre client version |
 | -------------- | ----- | --------------------- | --------------------- |
 | main branch | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-noble | 1.21+ | 2.15.7 (jammy) / 2.16.1 (noble) |
-| development branch | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:latest-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:latest-noble | 1.21+ | 2.15.8 (jammy) / 2.16.1 (noble) |
+| development branch | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:latest-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:latest-noble | 1.21+ | 2.15.8¹ (jammy) / 2.16.1 (noble) |
 | v0.4.0 | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-noble | 1.21+ | 2.15.7 |
 | v0.3.1 | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.3.1 | 1.21+ | 2.15.7 |
 | v0.3.0 | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.3.0 | 1.21+ | 2.15.5 |
@@ -29,6 +29,8 @@ Starting with v0.4.0, the driver ships separate images per Ubuntu distribution: 
 | v0.1.15 | mcr.microsoft.com/oss/kubernetes-csi/azurelustre-csi:v0.1.15 | 1.21+ | 2.15.4 |
 | v0.1.14 | mcr.microsoft.com/oss/kubernetes-csi/azurelustre-csi:v0.1.14 | 1.21+ | 2.15.3 |
 | v0.1.11 | mcr.microsoft.com/oss/kubernetes-csi/azurelustre-csi:v0.1.11 | 1.21+ | 2.15.1 |
+
+¹ Lustre 2.15.8 introduces the `unique_fsid` mount option, automatically enabled by the driver. This gives each volume mount its own filesystem ID, allowing Kubernetes to properly manage multiple Lustre volumes on a single node. See [driver-parameters.md](docs/driver-parameters.md#unique-filesystem-id-unique_fsid) for details.
 
 &nbsp;
 

--- a/deploy/csi-azurelustre-node-jammy.yaml
+++ b/deploy/csi-azurelustre-node-jammy.yaml
@@ -139,9 +139,9 @@ spec:
             - name: AZURELUSTRE_CSI_INSTALL_LUSTRE_CLIENT
               value: "yes"
             - name: LUSTRE_VERSION
-              value: "2.15.7"
+              value: "2.15.8"
             - name: CLIENT_SHA_SUFFIX
-              value: "33-g79ddf99"
+              value: "34-gc0f2040"
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/docs/driver-parameters.md
+++ b/docs/driver-parameters.md
@@ -27,6 +27,35 @@ This mechanism prevents pods requiring Azure Lustre storage from being scheduled
 - CSI driver components are not fully initialized
 - Network connectivity to Lustre filesystems is not established
 
+### Unique Filesystem ID (unique_fsid)
+
+Starting with Lustre client version 2.15.8, the CSI driver automatically adds the `unique_fsid` mount option to all Lustre mounts. This gives each mount its own filesystem ID, allowing Kubernetes to properly distinguish multiple mounts of the same Lustre filesystem on a single node.
+
+**Why this matters:** Without `unique_fsid`, all Lustre mounts of the same filesystem share the same device number (`st_dev`). Kubernetes identifies mounts by `(st_dev, fsroot)`, so it treats all mounts as a single device. This can cause unmount failures when multiple volumes are mounted on the same node, and limits the ability to scale pod density.
+
+**Behavior:**
+
+- **Automatic:** The driver detects the installed Lustre module version at first mount. If the version is >= 2.15.8, `unique_fsid` is added automatically. No user action is required.
+- **Conservative:** If the Lustre version cannot be determined, `unique_fsid` is not added. Existing behavior is preserved.
+- **Opt-out:** To disable auto-injection, add `no_unique_fsid` to the `mountOptions` in your PersistentVolume or StorageClass definition. This is a CSI-driver-level flag that is stripped before reaching the kernel.
+
+**Example — disabling unique_fsid:**
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+spec:
+  mountOptions:
+    - noatime
+    - flock
+    - no_unique_fsid  # Suppresses automatic unique_fsid injection
+  csi:
+    driver: azurelustre.csi.azure.com
+    ...
+```
+
+> **Note:** If the Lustre kernel module is upgraded on a node (e.g., from 2.15.7 to 2.15.8), the CSI driver DaemonSet pod must be restarted for the driver to detect the new version.
+
 ## Dynamic Provisioning (Create an AMLFS Cluster through AKS)
 
 ### Permissions For Kubelet Identity

--- a/pkg/azurelustre/azurelustre.go
+++ b/pkg/azurelustre/azurelustre.go
@@ -146,6 +146,9 @@ type Driver struct {
 	// for that same volume (as defined by VolumeID) return an Aborted error
 	volumeLocks      *volumeLocks
 	kernelModuleLock sync.Mutex
+	// lustreCapabilities detects and caches Lustre module capabilities
+	// (e.g., unique_fsid support). Lazily initialized on first mount.
+	lustreCapabilities *lustreCapabilities
 
 	cloud              *azure.Cloud
 	resourceGroup      string
@@ -170,6 +173,7 @@ func NewDriver(options *DriverOptions) *Driver {
 		enableAzureLustreMockDynProv: options.EnableAzureLustreMockDynProv,
 		workingMountDir:              options.WorkingMountDir,
 		removeNotReadyTaint:          options.RemoveNotReadyTaint,
+		lustreCapabilities:           &lustreCapabilities{},
 	}
 	d.Name = options.DriverName
 	d.Version = driverVersion

--- a/pkg/azurelustre/lustre_capabilities.go
+++ b/pkg/azurelustre/lustre_capabilities.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2025 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/azurelustre/lustre_capabilities.go
+++ b/pkg/azurelustre/lustre_capabilities.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azurelustre
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// lustreSysVersionPath is the sysfs path for the loaded Lustre module version.
+	lustreSysVersionPath = "/sys/module/lustre/version"
+
+	// uniqueFsidMinMajor, uniqueFsidMinMinor, uniqueFsidMinPatch define the
+	// minimum Lustre client version that supports the unique_fsid mount option.
+	uniqueFsidMinMajor = 2
+	uniqueFsidMinMinor = 15
+	uniqueFsidMinPatch = 8
+)
+
+// lustreCapabilities caches detected Lustre module capabilities so that
+// sysfs is read at most once per driver lifetime.
+//
+// Note: The cached result is permanent for the lifetime of the CSI DaemonSet
+// pod. If the Lustre kernel module is upgraded on a node (e.g., from 2.15.7
+// to 2.15.8), a DaemonSet pod restart is required for the driver to detect
+// the new capabilities.
+type lustreCapabilities struct {
+	once               sync.Once
+	supportsUniqueFsid bool
+	version            string
+}
+
+// SupportsUniqueFsid returns true if the loaded Lustre module supports
+// the unique_fsid mount option (>= 2.15.8). Detection is lazy — the
+// first call reads /sys/module/lustre/version, and the result is cached.
+// If the version cannot be determined, returns false (conservative).
+func (c *lustreCapabilities) SupportsUniqueFsid() bool {
+	c.once.Do(func() {
+		c.version, c.supportsUniqueFsid = detectUniqueFsidSupport()
+		if c.supportsUniqueFsid {
+			klog.V(2).Infof("Lustre module version %s supports unique_fsid", c.version)
+		} else {
+			klog.V(2).Infof("Lustre module version %q does not support unique_fsid (requires >= %d.%d.%d)",
+				c.version, uniqueFsidMinMajor, uniqueFsidMinMinor, uniqueFsidMinPatch)
+		}
+	})
+	return c.supportsUniqueFsid
+}
+
+// detectUniqueFsidSupport reads the Lustre module version from sysfs and
+// determines whether it meets the minimum version for unique_fsid support.
+func detectUniqueFsidSupport() (string, bool) {
+	version, err := readLustreVersion()
+	if err != nil {
+		klog.V(4).Infof("could not read Lustre version: %v", err)
+		return "", false
+	}
+
+	major, minor, patch, err := parseLustreVersion(version)
+	if err != nil {
+		klog.V(4).Infof("could not parse Lustre version %q: %v", version, err)
+		return version, false
+	}
+
+	supported := compareLustreVersion(major, minor, patch,
+		uniqueFsidMinMajor, uniqueFsidMinMinor, uniqueFsidMinPatch) >= 0
+	return version, supported
+}
+
+// readLustreVersion reads the Lustre module version from sysfs.
+func readLustreVersion() (string, error) {
+	data, err := os.ReadFile(lustreSysVersionPath)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", lustreSysVersionPath, err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// parseLustreVersion extracts major.minor.patch from a Lustre version string.
+// Handles formats like "2.15.8", "2.15.8_34_gc0f2040", "2.15.8-ddn1", etc.
+func parseLustreVersion(version string) (int, int, int, error) {
+	// Strip everything after the first non-numeric/non-dot character
+	// following the initial version prefix.
+	cleaned := version
+	for i, c := range version {
+		if i > 0 && c != '.' && (c < '0' || c > '9') {
+			cleaned = version[:i]
+			break
+		}
+	}
+
+	parts := strings.SplitN(cleaned, ".", 4)
+	if len(parts) < 3 {
+		return 0, 0, 0, fmt.Errorf("expected at least 3 version components in %q, got %d", version, len(parts))
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("parsing major version %q: %w", parts[0], err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("parsing minor version %q: %w", parts[1], err)
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("parsing patch version %q: %w", parts[2], err)
+	}
+
+	return major, minor, patch, nil
+}
+
+// compareLustreVersion compares two version tuples. Returns:
+//
+//	-1 if a < b
+//	 0 if a == b
+//	 1 if a > b
+func compareLustreVersion(aMajor, aMinor, aPatch, bMajor, bMinor, bPatch int) int {
+	if aMajor != bMajor {
+		if aMajor < bMajor {
+			return -1
+		}
+		return 1
+	}
+	if aMinor != bMinor {
+		if aMinor < bMinor {
+			return -1
+		}
+		return 1
+	}
+	if aPatch != bPatch {
+		if aPatch < bPatch {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}

--- a/pkg/azurelustre/lustre_capabilities_test.go
+++ b/pkg/azurelustre/lustre_capabilities_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright 2025 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/azurelustre/lustre_capabilities_test.go
+++ b/pkg/azurelustre/lustre_capabilities_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azurelustre
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLustreVersion(t *testing.T) {
+	tests := []struct {
+		name          string
+		version       string
+		expectMajor   int
+		expectMinor   int
+		expectPatch   int
+		expectErr     bool
+	}{
+		{
+			name:        "simple version",
+			version:     "2.15.8",
+			expectMajor: 2, expectMinor: 15, expectPatch: 8,
+		},
+		{
+			name:        "version with SHA suffix",
+			version:     "2.15.8_34_gc0f2040",
+			expectMajor: 2, expectMinor: 15, expectPatch: 8,
+		},
+		{
+			name:        "version with hyphen suffix",
+			version:     "2.15.8-ddn1",
+			expectMajor: 2, expectMinor: 15, expectPatch: 8,
+		},
+		{
+			name:        "older version",
+			version:     "2.15.7",
+			expectMajor: 2, expectMinor: 15, expectPatch: 7,
+		},
+		{
+			name:        "newer version",
+			version:     "2.16.1",
+			expectMajor: 2, expectMinor: 16, expectPatch: 1,
+		},
+		{
+			name:        "2.17 version",
+			version:     "2.17.0_42_gabcdef1",
+			expectMajor: 2, expectMinor: 17, expectPatch: 0,
+		},
+		{
+			name:      "too few components",
+			version:   "2.15",
+			expectErr: true,
+		},
+		{
+			name:      "empty string",
+			version:   "",
+			expectErr: true,
+		},
+		{
+			name:      "garbage",
+			version:   "not-a-version",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			major, minor, patch, err := parseLustreVersion(tt.version)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectMajor, major)
+				assert.Equal(t, tt.expectMinor, minor)
+				assert.Equal(t, tt.expectPatch, patch)
+			}
+		})
+	}
+}
+
+func TestCompareLustreVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		a      [3]int
+		b      [3]int
+		expect int
+	}{
+		{"equal", [3]int{2, 15, 8}, [3]int{2, 15, 8}, 0},
+		{"major less", [3]int{1, 15, 8}, [3]int{2, 15, 8}, -1},
+		{"major greater", [3]int{3, 15, 8}, [3]int{2, 15, 8}, 1},
+		{"minor less", [3]int{2, 14, 8}, [3]int{2, 15, 8}, -1},
+		{"minor greater", [3]int{2, 16, 0}, [3]int{2, 15, 8}, 1},
+		{"patch less", [3]int{2, 15, 7}, [3]int{2, 15, 8}, -1},
+		{"patch greater", [3]int{2, 15, 9}, [3]int{2, 15, 8}, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := compareLustreVersion(
+				tt.a[0], tt.a[1], tt.a[2],
+				tt.b[0], tt.b[1], tt.b[2],
+			)
+			assert.Equal(t, tt.expect, result)
+		})
+	}
+}
+
+func TestDetectUniqueFsidSupport(t *testing.T) {
+	// This test validates the logic chain from version string to support bool.
+	// It doesn't read sysfs — that's an integration concern.
+	tests := []struct {
+		name    string
+		version string
+		expect  bool
+	}{
+		{"exactly 2.15.8", "2.15.8", true},
+		{"2.15.8 with SHA", "2.15.8_34_gc0f2040", true},
+		{"2.15.7 too old", "2.15.7", false},
+		{"2.15.6 too old", "2.15.6", false},
+		{"2.16.1 newer", "2.16.1", true},
+		{"2.17.0 newer", "2.17.0", true},
+		{"2.14.0 too old", "2.14.0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			major, minor, patch, err := parseLustreVersion(tt.version)
+			require.NoError(t, err)
+			result := compareLustreVersion(major, minor, patch,
+				uniqueFsidMinMajor, uniqueFsidMinMinor, uniqueFsidMinPatch) >= 0
+			assert.Equal(t, tt.expect, result)
+		})
+	}
+}

--- a/pkg/azurelustre/nodeserver.go
+++ b/pkg/azurelustre/nodeserver.go
@@ -90,7 +90,7 @@ func (d *Driver) NodePublishVolume(
 
 	source := getSourceString(vol.mgsIPAddress, vol.azureLustreName)
 
-	mountOptions, readOnly := getMountOptions(req, userMountFlags)
+	mountOptions, readOnly := getMountOptions(req, userMountFlags, d.lustreCapabilities.SupportsUniqueFsid())
 
 	if len(vol.subDir) > 0 && !d.enableAzureLustreMockMount {
 		interpolatedSubDir := interpolateSubDirVariables(context, vol)
@@ -207,13 +207,17 @@ func interpolateSubDirVariables(context map[string]string, vol *lustreVolume) st
 	return interpolatedSubDir
 }
 
-func getMountOptions(req *csi.NodePublishVolumeRequest, userMountFlags []string) ([]string, bool) {
+func getMountOptions(req *csi.NodePublishVolumeRequest, userMountFlags []string, supportsUniqueFsid bool) ([]string, bool) {
 	readOnly := false
 	mountOptions := []string{}
 	if req.GetReadonly() {
 		readOnly = true
 		mountOptions = append(mountOptions, "ro")
 	}
+
+	userRequestedUniqueFsid := false
+	userDisabledUniqueFsid := false
+
 	for _, userMountFlag := range userMountFlags {
 		if userMountFlag == "ro" {
 			readOnly = true
@@ -222,8 +226,34 @@ func getMountOptions(req *csi.NodePublishVolumeRequest, userMountFlags []string)
 				continue
 			}
 		}
+		// Handle unique_fsid user overrides:
+		// - "unique_fsid": user explicitly wants it (don't add a duplicate)
+		// - "no_unique_fsid": user explicitly disables it (strip this sentinel,
+		//   don't auto-add unique_fsid)
+		if userMountFlag == "unique_fsid" {
+			userRequestedUniqueFsid = true
+		}
+		if userMountFlag == "no_unique_fsid" {
+			userDisabledUniqueFsid = true
+			continue // strip sentinel — not a real mount option
+		}
 		mountOptions = append(mountOptions, userMountFlag)
 	}
+
+	// Warn if user explicitly requested unique_fsid on an unsupported Lustre version
+	if userRequestedUniqueFsid && !supportsUniqueFsid {
+		klog.Warningf("user requested unique_fsid mount option but Lustre module may not support it (requires >= %d.%d.%d); mount may fail",
+			uniqueFsidMinMajor, uniqueFsidMinMinor, uniqueFsidMinPatch)
+	}
+
+	// Auto-inject unique_fsid when:
+	// 1. User didn't explicitly disable it (no_unique_fsid)
+	// 2. User didn't already request it (avoid duplicates)
+	// 3. The loaded Lustre module supports it (>= 2.15.8)
+	if !userDisabledUniqueFsid && !userRequestedUniqueFsid && supportsUniqueFsid {
+		mountOptions = append(mountOptions, "unique_fsid")
+	}
+
 	return mountOptions, readOnly
 }
 
@@ -383,10 +413,16 @@ func unmountVolumeAtPath(d *Driver, targetPath string) error {
 // calling GetDeviceMountRefs(deviceMountPath) around line 947.
 //
 // All Lustre mounts on a system, no matter where in the lustrefs they are
-// mounted to, all have '/' as the root and they all have the same major and
-// minor device numbers, so as far as this check is concerned, every lustre
-// mount is the same device, even though individual Lustre mount points can
-// be unmounted without affecting others and should not be a concern.
+// mounted to, historically all have '/' as the root and they all have the same
+// major and minor device numbers. This causes kubelet to treat every Lustre
+// mount as the same device, blocking unmount of one volume while another
+// volume's mount exists on the same node.
+//
+// The unique_fsid mount option (Lustre >= 2.15.8) fixes this at the kernel
+// level by assigning unique device numbers per mount. When unique_fsid is
+// available and enabled (the default for >= 2.15.8), this staging limitation
+// no longer applies. However, NodeStageVolume remains unimplemented until
+// the CSI driver is validated with per-volume staging end-to-end.
 //
 // With a single Lustre volume mount, this works fine. It stages to a
 // globalpath dir, pods can bind mount into that, and when the last pod is

--- a/pkg/azurelustre/nodeserver_test.go
+++ b/pkg/azurelustre/nodeserver_test.go
@@ -823,6 +823,110 @@ func TestNewSafeMounter(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestGetMountOptions(t *testing.T) {
+	volumeCap := csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER}
+
+	tests := []struct {
+		desc               string
+		readOnly           bool
+		userMountFlags     []string
+		supportsUniqueFsid bool
+		expectOptions      []string
+		expectReadOnly     bool
+	}{
+		{
+			desc:               "auto-inject unique_fsid when supported",
+			userMountFlags:     []string{"noatime", "flock"},
+			supportsUniqueFsid: true,
+			expectOptions:      []string{"noatime", "flock", "unique_fsid"},
+			expectReadOnly:     false,
+		},
+		{
+			desc:               "no unique_fsid when unsupported",
+			userMountFlags:     []string{"noatime", "flock"},
+			supportsUniqueFsid: false,
+			expectOptions:      []string{"noatime", "flock"},
+			expectReadOnly:     false,
+		},
+		{
+			desc:               "no_unique_fsid suppresses auto-inject",
+			userMountFlags:     []string{"noatime", "no_unique_fsid"},
+			supportsUniqueFsid: true,
+			expectOptions:      []string{"noatime"},
+			expectReadOnly:     false,
+		},
+		{
+			desc:               "no_unique_fsid stripped even when unsupported",
+			userMountFlags:     []string{"no_unique_fsid", "flock"},
+			supportsUniqueFsid: false,
+			expectOptions:      []string{"flock"},
+			expectReadOnly:     false,
+		},
+		{
+			desc:               "explicit unique_fsid not duplicated",
+			userMountFlags:     []string{"unique_fsid", "noatime"},
+			supportsUniqueFsid: true,
+			expectOptions:      []string{"unique_fsid", "noatime"},
+			expectReadOnly:     false,
+		},
+		{
+			desc:               "explicit unique_fsid preserved when unsupported",
+			userMountFlags:     []string{"unique_fsid"},
+			supportsUniqueFsid: false,
+			expectOptions:      []string{"unique_fsid"},
+			expectReadOnly:     false,
+		},
+		{
+			desc:               "conflicting flags — unique_fsid wins over no_unique_fsid",
+			userMountFlags:     []string{"unique_fsid", "no_unique_fsid"},
+			supportsUniqueFsid: true,
+			expectOptions:      []string{"unique_fsid"},
+			expectReadOnly:     false,
+		},
+		{
+			desc:               "read-only with unique_fsid",
+			readOnly:           true,
+			userMountFlags:     []string{"noatime"},
+			supportsUniqueFsid: true,
+			expectOptions:      []string{"ro", "noatime", "unique_fsid"},
+			expectReadOnly:     true,
+		},
+		{
+			desc:               "empty user flags with unique_fsid",
+			userMountFlags:     []string{},
+			supportsUniqueFsid: true,
+			expectOptions:      []string{"unique_fsid"},
+			expectReadOnly:     false,
+		},
+		{
+			desc:               "nil user flags with unique_fsid",
+			userMountFlags:     nil,
+			supportsUniqueFsid: true,
+			expectOptions:      []string{"unique_fsid"},
+			expectReadOnly:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			req := &csi.NodePublishVolumeRequest{
+				Readonly: tt.readOnly,
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &volumeCap,
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{
+							MountFlags: tt.userMountFlags,
+						},
+					},
+				},
+			}
+			options, readOnly := getMountOptions(req, tt.userMountFlags, tt.supportsUniqueFsid)
+			assert.Equal(t, tt.expectOptions, options, "mount options mismatch")
+			assert.Equal(t, tt.expectReadOnly, readOnly, "readOnly mismatch")
+		})
+	}
+}
+
 func TestNodeGetVolumeStats(t *testing.T) {
 	nonexistedPath := "/not/a/real/directory"
 	fakePath := "/tmp/fake-volume-path"

--- a/test/external-e2e/test_unique_fsid.sh
+++ b/test/external-e2e/test_unique_fsid.sh
@@ -1,0 +1,339 @@
+#!/bin/bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# End-to-end tests for the unique_fsid mount option.
+#
+# Requires:
+#   - kubectl configured for an AKS cluster with the CSI driver installed
+#   - Lustre >= 2.15.8 kmod on the nodes
+#   - An AMLFS filesystem accessible from the cluster
+#
+# Usage:
+#   LUSTRE_FS_NAME=lustrefs LUSTRE_MGS_IP=10.1.0.7 ./test_unique_fsid.sh
+#
+# Tests:
+#   1. unique_fsid auto-injected in mount options
+#   2. Two volumes on same node get different f_fsid
+#   3. no_unique_fsid suppresses auto-injection and produces same f_fsid
+#   4. Unmounting one volume doesn't affect another
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o xtrace
+
+readonly LUSTRE_FS_NAME=${LUSTRE_FS_NAME:?Set LUSTRE_FS_NAME (e.g. lustrefs)}
+readonly LUSTRE_MGS_IP=${LUSTRE_MGS_IP:?Set LUSTRE_MGS_IP (e.g. 10.1.0.7)}
+readonly NAMESPACE=${NAMESPACE:-default}
+readonly TIMEOUT=${TIMEOUT:-120s}
+readonly SC_NAME="sc-unique-fsid-test"
+readonly REPO_ROOT_PATH=${REPO_ROOT_PATH:-$(git rev-parse --show-toplevel)}
+readonly TEST_POD_IMAGE=${TEST_POD_IMAGE:-alpine}
+
+PASS=0
+FAIL=0
+
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+    echo ""
+    echo "=== Collecting CSI driver logs ==="
+    bash "${REPO_ROOT_PATH}/utils/azurelustre_log.sh" 2>/dev/null || true
+    echo "=== Cleaning up test resources (pods, then PVCs, then PVs) ==="
+    for i in 1 2 3 4; do
+        kubectl delete pod "fsid-test-pod-${i}" -n "$NAMESPACE" --ignore-not-found --grace-period=5 2>/dev/null || true
+    done
+    sleep 5
+    for i in 1 2 3 4; do
+        kubectl delete pvc "pvc-fsid-test-${i}" -n "$NAMESPACE" --ignore-not-found 2>/dev/null || true
+    done
+    for i in 1 2 3 4; do
+        kubectl delete pv "pv-fsid-test-${i}" --ignore-not-found 2>/dev/null || true
+    done
+    kubectl delete storageclass "$SC_NAME" --ignore-not-found 2>/dev/null || true
+    echo "=== Cleanup complete ==="
+}
+trap cleanup EXIT
+
+get_node_name() {
+    local pod_name=$1
+    kubectl get pod "$pod_name" -n "$NAMESPACE" -o jsonpath='{.spec.nodeName}'
+}
+
+check_mount_options() {
+    local node=$1
+    local search=$2
+    # Read host-level /proc/mounts via nsenter from the CSI node pod on the target node.
+    # kubectl debug doesn't work reliably without a TTY in scripts.
+    local csi_pod
+    csi_pod=$(kubectl get pods -n kube-system -l app=csi-azurelustre-node \
+        --field-selector "spec.nodeName=${node}" -o name | head -1)
+    if [[ -z "$csi_pod" ]]; then
+        echo ""
+        return
+    fi
+    kubectl exec -n kube-system "${csi_pod}" -c azurelustre -- \
+        nsenter -t 1 -m -- cat /proc/mounts 2>/dev/null | grep "$search" || true
+}
+
+get_fsid() {
+    local pod_name=$1
+    local fsid
+    fsid=$(kubectl exec "$pod_name" -n "$NAMESPACE" -- \
+        stat -f -c '%i' /mnt/lustre 2>/dev/null) || fsid=""
+    if [[ -z "$fsid" ]]; then
+        fail "Could not read f_fsid from ${pod_name}"
+        return 1
+    fi
+    echo "$fsid"
+}
+
+# Pick a node to pin all test pods to
+NODE=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+echo "=== unique_fsid E2E tests ==="
+echo "Lustre: ${LUSTRE_FS_NAME} @ ${LUSTRE_MGS_IP}"
+echo "Node: ${NODE}"
+echo ""
+
+# --- Create StorageClass ---
+kubectl apply -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ${SC_NAME}
+provisioner: azurelustre.csi.azure.com
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+mountOptions:
+  - noatime
+  - flock
+EOF
+
+# --- Test 1 & 2: Create two PVs with unique_fsid (auto) ---
+for i in 1 2; do
+    PV_YAML=$(cat <<EOF
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-fsid-test-${i}
+spec:
+  accessModes: [ReadWriteMany]
+  capacity:
+    storage: 4Ti
+  csi:
+    driver: azurelustre.csi.azure.com
+    volumeAttributes:
+      fs-name: ${LUSTRE_FS_NAME}
+      mgs-ip-address: ${LUSTRE_MGS_IP}
+      sub-dir: fsid-test-${i}
+    volumeHandle: fsid-test-vol-${i}
+  mountOptions: [noatime, flock]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ${SC_NAME}
+EOF
+    )
+    echo "$PV_YAML" | kubectl apply -f -
+
+    PVC_YAML=$(cat <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-fsid-test-${i}
+  namespace: ${NAMESPACE}
+spec:
+  accessModes: [ReadWriteMany]
+  resources:
+    requests:
+      storage: 4Ti
+  storageClassName: ${SC_NAME}
+  volumeName: pv-fsid-test-${i}
+EOF
+    )
+    echo "$PVC_YAML" | kubectl apply -f -
+
+    POD_YAML=$(cat <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fsid-test-pod-${i}
+  namespace: ${NAMESPACE}
+spec:
+  nodeName: ${NODE}
+  containers:
+  - name: test
+    image: ${TEST_POD_IMAGE}
+    command: [sh, -c, "while true; do sleep 3600; done"]
+    volumeMounts:
+    - mountPath: /mnt/lustre
+      name: vol
+  volumes:
+  - name: vol
+    persistentVolumeClaim:
+      claimName: pvc-fsid-test-${i}
+EOF
+    )
+    echo "$POD_YAML" | kubectl apply -f -
+done
+
+echo "Waiting for pods..."
+kubectl wait --for=condition=ready pod/fsid-test-pod-1 pod/fsid-test-pod-2 \
+    -n "$NAMESPACE" --timeout="$TIMEOUT"
+
+# Test 1: Check unique_fsid in mount options
+echo ""
+echo "=== Test 1: unique_fsid auto-injection ==="
+MOUNT_LINE=$(check_mount_options "$NODE" "fsid-test-1" | head -1)
+if echo "$MOUNT_LINE" | grep -q "unique_fsid"; then
+    pass "unique_fsid found in mount options"
+else
+    fail "unique_fsid NOT found in mount options: $MOUNT_LINE"
+fi
+
+# Test 2: Different f_fsid
+echo ""
+echo "=== Test 2: unique f_fsid per volume ==="
+FSID1=$(get_fsid fsid-test-pod-1) || exit 1
+FSID2=$(get_fsid fsid-test-pod-2) || exit 1
+echo "  Volume 1 fsid: ${FSID1}"
+echo "  Volume 2 fsid: ${FSID2}"
+if [[ "$FSID1" != "$FSID2" ]]; then
+    pass "Different f_fsid values"
+else
+    fail "Same f_fsid — unique_fsid may not be working"
+fi
+
+# --- Test 3: no_unique_fsid opt-out ---
+echo ""
+echo "=== Test 3: no_unique_fsid opt-out ==="
+for i in 3 4; do
+    PV_YAML=$(cat <<EOF
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-fsid-test-${i}
+spec:
+  accessModes: [ReadWriteMany]
+  capacity:
+    storage: 4Ti
+  csi:
+    driver: azurelustre.csi.azure.com
+    volumeAttributes:
+      fs-name: ${LUSTRE_FS_NAME}
+      mgs-ip-address: ${LUSTRE_MGS_IP}
+      sub-dir: fsid-test-${i}
+    volumeHandle: fsid-test-vol-${i}
+  mountOptions: [noatime, flock, no_unique_fsid]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ${SC_NAME}
+EOF
+    )
+    echo "$PV_YAML" | kubectl apply -f -
+
+    PVC_YAML=$(cat <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-fsid-test-${i}
+  namespace: ${NAMESPACE}
+spec:
+  accessModes: [ReadWriteMany]
+  resources:
+    requests:
+      storage: 4Ti
+  storageClassName: ${SC_NAME}
+  volumeName: pv-fsid-test-${i}
+EOF
+    )
+    echo "$PVC_YAML" | kubectl apply -f -
+
+    POD_YAML=$(cat <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fsid-test-pod-${i}
+  namespace: ${NAMESPACE}
+spec:
+  nodeName: ${NODE}
+  containers:
+  - name: test
+    image: ${TEST_POD_IMAGE}
+    command: [sh, -c, "while true; do sleep 3600; done"]
+    volumeMounts:
+    - mountPath: /mnt/lustre
+      name: vol
+  volumes:
+  - name: vol
+    persistentVolumeClaim:
+      claimName: pvc-fsid-test-${i}
+EOF
+    )
+    echo "$POD_YAML" | kubectl apply -f -
+done
+
+kubectl wait --for=condition=ready pod/fsid-test-pod-3 pod/fsid-test-pod-4 \
+    -n "$NAMESPACE" --timeout="$TIMEOUT"
+
+FSID3=$(get_fsid fsid-test-pod-3) || exit 1
+FSID4=$(get_fsid fsid-test-pod-4) || exit 1
+echo "  Volume 3 fsid: ${FSID3}"
+echo "  Volume 4 fsid: ${FSID4}"
+if [[ "$FSID3" == "$FSID4" ]]; then
+    pass "Same f_fsid with no_unique_fsid (shared behavior restored)"
+else
+    fail "Different f_fsid despite no_unique_fsid"
+fi
+
+# Check sentinel was stripped
+MOUNT_LINE_3=$(check_mount_options "$NODE" "fsid-test-3" | head -1)
+if echo "$MOUNT_LINE_3" | grep -q "no_unique_fsid"; then
+    fail "no_unique_fsid sentinel leaked to kernel mount options"
+else
+    pass "no_unique_fsid sentinel correctly stripped"
+fi
+
+# --- Test 4: Unmount isolation ---
+echo ""
+echo "=== Test 4: unmount isolation ==="
+kubectl delete pod fsid-test-pod-2 -n "$NAMESPACE" --grace-period=5
+kubectl delete pvc pvc-fsid-test-2 -n "$NAMESPACE"
+kubectl wait --for=delete pod/fsid-test-pod-2 -n "$NAMESPACE" --timeout="$TIMEOUT" 2>/dev/null || true
+sleep 5
+
+if kubectl exec fsid-test-pod-1 -n "$NAMESPACE" -- ls /mnt/lustre >/dev/null 2>&1; then
+    pass "Volume 1 still accessible after unmounting volume 2"
+else
+    fail "Volume 1 broken after unmounting volume 2"
+fi
+
+if kubectl exec fsid-test-pod-3 -n "$NAMESPACE" -- ls /mnt/lustre >/dev/null 2>&1; then
+    pass "Volume 3 (no_unique_fsid) still accessible after unmounting volume 2"
+else
+    fail "Volume 3 broken after unmounting volume 2"
+fi
+
+# --- Summary ---
+echo ""
+echo "==============================="
+echo "  unique_fsid E2E results"
+echo "  PASSED: ${PASS}"
+echo "  FAILED: ${FAIL}"
+echo "==============================="
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

Automatically adds the `unique_fsid` Lustre mount option when the loaded kernel module supports it (>= 2.15.8). This gives each mount its own filesystem ID so Kubernetes can properly distinguish multiple mounts of the same Lustre filesystem on a single node.

### Problem

Lustre historically forces a shared `s_dev` across all mounts of the same filesystem. Kubernetes identifies mounts by `(st_dev, fsroot)`, so it can't distinguish multiple mounts — all Lustre mounts look like the same device. This causes kubelet to block unmount of one volume while another volume's mount exists on the same node (documented in detail in the existing NodeStageVolume comment).

At scale (~110 pods/node), all pods funnel through a single Lustre client mount point, creating a performance bottleneck.

### Solution

The `unique_fsid` kernel mount option (commit c0f2040a9e in 2.15.8-client) skips the UUID-to-s_dev assignment, yielding unique FSIDs per mount. This PR:

1. **Lazy capability detection** — reads `/sys/module/lustre/version` on first mount, caches the result via `sync.Once`
2. **Auto-injection** — adds `unique_fsid` to mount options when Lustre >= 2.15.8
3. **Conservative default** — if version can't be determined, does NOT add the flag
4. **User overrides** — `no_unique_fsid` in mount options suppresses auto-injection; explicit `unique_fsid` is not duplicated
5. **Warning** — logs when user explicitly requests `unique_fsid` on an unsupported version

## Which issue(s) this PR fixes

AB#37726751

## Special notes for your reviewer

- The capability detection is on the `Driver` struct (not a package global) for testability
- `getMountOptions` is a pure function — takes `supportsUniqueFsid bool` parameter, fully testable
- `no_unique_fsid` is a CSI-driver-level sentinel, stripped before reaching the kernel
- NodeStageVolume remains unimplemented — this sets up the precondition but the staging change is a separate validation effort
- DaemonSet pod restart required after kmod upgrade for detection to refresh (documented in code)

## Requirements
- [x] uses conventional commit messages
- [x] includes documentation (updated NodeStageVolume comment)
- [x] adds unit tests
- [ ] tested upgrade from previous version

```release-note
feat: Auto-inject unique_fsid mount option for Lustre >= 2.15.8, enabling Kubernetes to distinguish multiple mounts of the same filesystem on a single node.
```