### PR TITLE
Makefile: centralize flavor configuration; refactor docker targets to…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,43 @@ ifeq ($(ARCH),arm64)
   export CC
 endif
 
+#
+# Image flavors
+#
+# Source of truth for what OS flavors we build container images for. Listed in
+# buckets by architecture support so docker targets and CI tooling can pick
+# the right subset for the current ARCH. Per-flavor SRC_IMAGE_<flavor> is the
+# base image passed as --build-arg srcImage to the Dockerfile.
+#
+# To add a new flavor:
+#   1. Add its name to AMD64_ONLY_FLAVORS or ALL_ARCHES_FLAVORS below.
+#   2. Define SRC_IMAGE_<flavor>.
+#   3. Add the matching files in deploy/, charts/, dalec/ (no Makefile changes).
+
+AMD64_ONLY_FLAVORS := jammy
+ALL_ARCHES_FLAVORS := noble
+ALL_FLAVORS := $(AMD64_ONLY_FLAVORS) $(ALL_ARCHES_FLAVORS)
+
+SRC_IMAGE_jammy := ubuntu:22.04
+SRC_IMAGE_noble := ubuntu:24.04
+
+# Fail fast if any declared flavor is missing its SRC_IMAGE_<flavor>.
+# Without this, a missing var would silently expand to empty and the Dockerfile's
+# ARG srcImage default would be used, producing a wrong-base image.
+$(foreach f,$(ALL_FLAVORS),$(if $(strip $(SRC_IMAGE_$(f))),,$(error Missing SRC_IMAGE_$(f) for flavor '$(f)')))
+
+# Fail fast if any flavor collides with an umbrella suffix. `push-latest-foo`
+# (etc.) is fine, but a flavor literally named `latest` or `commit` would
+# shadow the umbrellas via the longer-prefix pattern rules.
+$(if $(filter latest commit,$(ALL_FLAVORS)),$(error Reserved flavor names: 'latest', 'commit' (collide with push-latest / push-commit umbrellas)))
+
+# Flavors built for the current ARCH.
+ifeq ($(ARCH),amd64)
+  FLAVORS := $(ALL_FLAVORS)
+else
+  FLAVORS := $(ALL_ARCHES_FLAVORS)
+endif
+
 all: azurelustre
 
 #
@@ -85,82 +122,110 @@ azurelustre-dalec:
 	GOOS=linux go build -a -ldflags ${LDFLAGS} -mod vendor -o /app/azurelustreplugin ./pkg/azurelustreplugin
 
 #
-# Azure Lustre: Docker build
+# Azure Lustre: Docker build / tag / push
 #
-# Jammy is amd64-only. Noble supports amd64 and arm64.
-.PHONY: docker-build
-docker-build:
-ifeq ($(ARCH),amd64)
-	docker build --platform=linux/amd64 -t $(IMAGE_TAG)-jammy --build-arg srcImage=ubuntu:22.04 --output=type=docker -f ./pkg/azurelustreplugin/Dockerfile .
-endif
-	docker build --platform=linux/$(ARCH) -t $(IMAGE_TAG)-noble --build-arg srcImage=ubuntu:24.04 --output=type=docker -f ./pkg/azurelustreplugin/Dockerfile .
-.PHONY: quickcontainer
-quickcontainer: quicklustre docker-build
-.PHONY: container
-container: azurelustre docker-build
+# Each operation (build, push, tag-latest, push-latest, tag-commit,
+# push-commit) is a pattern rule with a `-<flavor>` suffix. An umbrella
+# target with no suffix fans out to one per-flavor target per entry in
+# $(FLAVORS), and the full build/tag/push dependency chain is expressed on
+# the pattern rules themselves so single-flavor invocations and `make -j`
+# all do the right thing.
+#
+# Maintainer note: do NOT add `docker-build` or `tag-latest` as direct
+# prereqs of a higher-level umbrella (e.g. `push: docker-build`). Under
+# `make -j` that reintroduces a race where pushes for one flavor can begin
+# before the build for another finishes. Express ordering on the pattern
+# rules instead, as is done below.
+#
+# `make docker-build-jammy`, `make push-noble`, etc. work as single-flavor
+# targets.
+#
+# Naming: flavor names must not be `latest` or `commit`, since
+# `push-latest` and `push-commit` are existing umbrella targets and would
+# collide with hypothetical `push-<flavor>` instances.
 
+# FORCE is a no-op prereq added to every pattern rule below.
 #
-# Azure Lustre: Docker tag & push
-#
+# Pattern rules only fire when their target doesn't already exist as a file.
+# If a file named e.g. `docker-build-jammy` were to appear in the working
+# directory (a build artifact, an accidental `touch`, a tab-completion typo),
+# make would consider the target up-to-date and skip the recipe. Depending on
+# FORCE (which is itself `.PHONY` and has no recipe) marks the target as
+# always-out-of-date so the recipe always runs.
+.PHONY: FORCE
+FORCE:
+
+.PHONY: docker-build
+docker-build: $(addprefix docker-build-,$(FLAVORS))
+
+# Fail at make-time unless $1 is a flavor buildable for the current $(ARCH).
+check-flavor = $(if $(filter $1,$(FLAVORS)),,$(error '$1' is not a known flavor for ARCH=$(ARCH). Valid flavors: $(FLAVORS)))
+
+docker-build-%: FORCE
+	$(call check-flavor,$*)
+	docker build --platform=linux/$(ARCH) -t $(IMAGE_TAG)-$* --build-arg srcImage=$(SRC_IMAGE_$*) --output=type=docker -f ./pkg/azurelustreplugin/Dockerfile .
+
 .PHONY: push
-push:
-ifeq ($(ARCH),amd64)
-	docker push $(IMAGE_TAG)-jammy
-endif
-	docker push $(IMAGE_TAG)-noble
+push: $(addprefix push-,$(FLAVORS))
+
+push-%: docker-build-% FORCE
+	docker push $(IMAGE_TAG)-$*
 
 .PHONY: tag-latest
-tag-latest:
-ifeq ($(ARCH),amd64)
-	docker tag $(IMAGE_TAG)-jammy $(IMAGE_TAG_LATEST)-jammy
-endif
-	docker tag $(IMAGE_TAG)-noble $(IMAGE_TAG_LATEST)-noble
+tag-latest: $(addprefix tag-latest-,$(FLAVORS))
+
+tag-latest-%: docker-build-% FORCE
+	docker tag $(IMAGE_TAG)-$* $(IMAGE_TAG_LATEST)-$*
 
 .PHONY: push-latest
-push-latest: tag-latest
-ifeq ($(ARCH),amd64)
-	docker push $(IMAGE_TAG_LATEST)-jammy
-endif
-	docker push $(IMAGE_TAG_LATEST)-noble
+push-latest: $(addprefix push-latest-,$(FLAVORS))
+
+push-latest-%: tag-latest-% FORCE
+	docker push $(IMAGE_TAG_LATEST)-$*
 
 .PHONY: tag-commit
-tag-commit: tag-latest
-ifeq ($(ARCH),amd64)
-	docker tag $(IMAGE_TAG_LATEST)-jammy $(IMAGE_TAG_COMMIT)-jammy
-endif
-	docker tag $(IMAGE_TAG_LATEST)-noble $(IMAGE_TAG_COMMIT)-noble
+tag-commit: $(addprefix tag-commit-,$(FLAVORS))
+
+tag-commit-%: tag-latest-% FORCE
+	docker tag $(IMAGE_TAG_LATEST)-$* $(IMAGE_TAG_COMMIT)-$*
 
 .PHONY: push-commit
-push-commit: tag-commit
-ifeq ($(ARCH),amd64)
-	docker push $(IMAGE_TAG_COMMIT)-jammy
-endif
-	docker push $(IMAGE_TAG_COMMIT)-noble
+push-commit: $(addprefix push-commit-,$(FLAVORS))
+
+push-commit-%: tag-commit-% FORCE
+	docker push $(IMAGE_TAG_COMMIT)-$*
 
 # Print the list of image flavors built for the current ARCH.
 # Used by CI pipelines to discover flavors without parsing Makefile variables.
 .PHONY: print-flavors
 print-flavors:
-ifeq ($(ARCH),amd64)
-	@echo jammy noble
-else
-	@echo noble
-endif
+	@echo $(FLAVORS)
 
-.PHONY: build-push
-build-push: container push
-
-.PHONY: build-push-quick
-build-push-quick: quickcontainer push
-
+#
+# Convenience aggregates
+#
+# The Go-binary build and the docker pipeline are independent dependency
+# graphs. Expressing one as a make prereq of the other would either re-run
+# docker work whenever the binary rebuilds or re-run the Go build for every
+# docker invocation, so the aggregates use recursive `$(MAKE)` to sequence
+# the two stages. MAKEFLAGS (ARCH, `-j`, etc.) inherit through `$(MAKE)`.
 .PHONY: build-push-latest
-build-push-latest: container push-latest
+build-push-latest:
+	$(MAKE) azurelustre
+	$(MAKE) push-latest
 
 .PHONY: build-push-latest-commit
-build-push-latest-commit: container push-latest push-commit
+build-push-latest-commit:
+	$(MAKE) azurelustre
+	$(MAKE) push-latest push-commit
 
-.PHONY: build-push-quick-latest
-build-push-quick-latest: quickcontainer push-latest
+# `container` is the conventional CSI driver entry point for building images
+# locally (see azurefile-csi-driver, azuredisk-csi-driver, blob-csi-driver).
+# Kept as a thin wrapper so external scripts and muscle memory still work.
+.PHONY: container
+container:
+	$(MAKE) azurelustre
+	$(MAKE) docker-build
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
… loop

Replaces 7 copies of the 'ifeq amd64 ... endif' pattern with two named flavor buckets and $(foreach) loops over the docker build/push/tag targets.

Buckets:
- AMD64_ONLY_FLAVORS: flavors built only for amd64 (no arm64 packages exist upstream). Currently jammy.
- ALL_ARCHES_FLAVORS: flavors built for both amd64 and arm64. Currently noble.

Both are concatenated into ALL_FLAVORS, from which FLAVORS is derived as the subset buildable on the current ARCH.

Each flavor needs SRC_IMAGE_<flavor> for the docker --build-arg srcImage lookup.

Adding a new flavor now means adding its name to one bucket and defining its SRC_IMAGE_<flavor>; the docker build/push/tag targets and print-flavors pick it up automatically.

print-flavors is stable: it was already used by CI pipelines and continues to print the same values for the existing flavors.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Requirements**:
- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Special notes for your reviewer**:


**Release note**:
```
none
```
