### PR TITLE
Azure Linux 3 node support.

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -59,3 +59,13 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+        with:
+          image-ref: 'test/azurelustre-csi:latest-azurelinux3'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'

--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,22 @@ endif
 # To add a new flavor:
 #   1. Add its name to AMD64_ONLY_FLAVORS or ALL_ARCHES_FLAVORS below.
 #   2. Define SRC_IMAGE_<flavor>.
-#   3. Add the matching files in deploy/, charts/, dalec/ (no Makefile changes).
+#   3. Add the matching files in deploy/, charts/, dalec/.
+#   4. If the shared Dockerfile is not suitable, define DOCKERFILE_<flavor>
+#      to point at a flavor-specific Dockerfile (see DOCKERFILE_azurelinux3).
 
-AMD64_ONLY_FLAVORS := jammy
+AMD64_ONLY_FLAVORS := jammy azurelinux3
 ALL_ARCHES_FLAVORS := noble
 ALL_FLAVORS := $(AMD64_ONLY_FLAVORS) $(ALL_ARCHES_FLAVORS)
 
 SRC_IMAGE_jammy := ubuntu:22.04
 SRC_IMAGE_noble := ubuntu:24.04
+SRC_IMAGE_azurelinux3 := mcr.microsoft.com/azurelinux/base/core:3.0
+
+# Per-flavor Dockerfile override. Defaults to the shared Dockerfile.
+DOCKERFILE = ./pkg/azurelustreplugin/Dockerfile
+DOCKERFILE_azurelinux3 = ./pkg/azurelustreplugin/Dockerfile.azurelinux3
+dockerfile-for = $(or $(DOCKERFILE_$1),$(DOCKERFILE))
 
 # Fail fast if any declared flavor is missing its SRC_IMAGE_<flavor>.
 # Without this, a missing var would silently expand to empty and the Dockerfile's
@@ -163,7 +171,7 @@ check-flavor = $(if $(filter $1,$(FLAVORS)),,$(error '$1' is not a known flavor 
 
 docker-build-%: FORCE
 	$(call check-flavor,$*)
-	docker build --platform=linux/$(ARCH) -t $(IMAGE_TAG)-$* --build-arg srcImage=$(SRC_IMAGE_$*) --output=type=docker -f ./pkg/azurelustreplugin/Dockerfile .
+	docker build --platform=linux/$(ARCH) -t $(IMAGE_TAG)-$* --build-arg srcImage=$(SRC_IMAGE_$*) --output=type=docker -f $(call dockerfile-for,$*) .
 
 .PHONY: push
 push: $(addprefix push-,$(FLAVORS))

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ This driver allows Kubernetes to access Azure Lustre file system.
 
 ## Container Images & Kubernetes Compatibility
 
-Starting with v0.4.0, the driver ships separate images per Ubuntu distribution: `-jammy` (22.04) and `-noble` (24.04). See [deploy/README-distribution-specific.md](deploy/README-distribution-specific.md) for details.
+Starting with v0.4.0, the driver ships separate images per node OS: `-jammy` (Ubuntu 22.04) and `-noble` (Ubuntu 24.04). An `-azurelinux3` (Azure Linux 3) image is currently available on the development branch. See [deploy/README-distribution-specific.md](deploy/README-distribution-specific.md) for details.
 
 | Driver version | Image | Supported k8s version | Lustre client version |
 | -------------- | ----- | --------------------- | --------------------- |
-| main branch | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-noble | 1.21+ | 2.15.7 (jammy) / 2.16.1 (noble) |
-| development branch | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:latest-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:latest-noble | 1.21+ | 2.15.8 (jammy) / 2.16.1 (noble) |
-| v0.4.0 | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-noble | 1.21+ | 2.15.7 |
+| main branch | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-noble | 1.21+ | 2.15.7 (jammy)<br>2.16.1 (noble) |
+| development branch | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:latest-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:latest-noble<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:latest-azurelinux3 | 1.21+ | 2.15.8 (jammy)<br>2.17.0 (noble)<br>2.17.0 (azurelinux3) |
+| v0.4.0 | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy<br>mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-noble | 1.21+ | 2.15.7 (jammy)<br>2.16.1 (noble) |
 | v0.3.1 | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.3.1 | 1.21+ | 2.15.7 |
 | v0.3.0 | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.3.0 | 1.21+ | 2.15.5 |
 | v0.2.0 | mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.2.0 | 1.21+ | 2.15.5 |

--- a/deploy/README-distribution-specific.md
+++ b/deploy/README-distribution-specific.md
@@ -2,19 +2,20 @@
 
 ## Overview
 
-This directory contains distribution-specific DaemonSet deployments for the Azure Lustre CSI driver. Each deployment targets a specific Ubuntu version to ensure proper Lustre client compatibility.
+This directory contains distribution-specific DaemonSet deployments for the Azure Lustre CSI driver. Each deployment targets a specific OS version to ensure proper Lustre client compatibility.
 
 ## Files
 
 - `csi-azurelustre-node-jammy.yaml` - Ubuntu 22.04 (Jammy) nodes
 - `csi-azurelustre-node-noble.yaml` - Ubuntu 24.04 (Noble) nodes
+- `csi-azurelustre-node-azurelinux3.yaml` - Azure Linux 3 nodes
 
 ## Distribution Targeting
 
 Each deployment uses:
 
 1. **Node Targeting**: Uses node affinity and selectors to match correct node OS flavors
-2. **Container Image**: Version-specific image tags like `v0.4.0-jammy`, `v0.4.0-noble`
+2. **Container Image**: Version-specific image tags like `v0.4.0-jammy`, `v0.4.0-noble`, `v0.4.0-azurelinux3`
 3. **Unique Names**: Each DaemonSet has a unique name (`csi-azurelustre-node-jammy`) to prevent conflicts
 
 ## Installation
@@ -36,6 +37,7 @@ Your AKS cluster nodes must have the `kubernetes.azure.com/os-sku-effective` lab
 
 - `Ubuntu2204`
 - `Ubuntu2404`
+- `AzureLinux3`
 
 AKS automatically sets this label based on the node pool's OS configuration.
 
@@ -45,8 +47,11 @@ Container images follow the pattern:
 
 - `mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-jammy`
 - `mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-noble`
+- `mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:v0.4.0-azurelinux3`
 
-Each image contains an Ubuntu version capable of installing the Lustre client packages compiled for the target distribution.
+Ubuntu images use `apt-get` to install Lustre client deb packages. The Azure Linux 3 image
+uses `tdnf` to install Lustre client RPM packages. Both use the same `amlfs-lustre-client-*`
+metapackage to keep kernel modules and userspace tools in sync.
 
 ## Troubleshooting
 
@@ -61,4 +66,5 @@ To check DaemonSet pod distribution:
 ```bash
 kubectl get pods -n kube-system -l app=csi-azurelustre-node,flavor=jammy -o wide
 kubectl get pods -n kube-system -l app=csi-azurelustre-node,flavor=noble -o wide
+kubectl get pods -n kube-system -l app=csi-azurelustre-node,flavor=azurelinux3 -o wide
 ```

--- a/deploy/csi-azurelustre-node-azurelinux3.yaml
+++ b/deploy/csi-azurelustre-node-azurelinux3.yaml
@@ -1,0 +1,204 @@
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-azurelustre-node-azurelinux3
+  namespace: kube-system
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-azurelustre-node
+      flavor: azurelinux3
+  template:
+    metadata:
+      labels:
+        app: csi-azurelustre-node
+        flavor: azurelinux3
+    spec:
+      hostNetwork: true
+      dnsPolicy: Default
+      serviceAccountName: csi-azurelustre-node-sa
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
+        kubernetes.azure.com/os-sku-effective: AzureLinux3
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: NotIn
+                    values:
+                      - virtual-kubelet
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: "Exists"
+      containers:
+        - name: liveness-probe
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.15.0
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=120s
+            - --health-port=29763
+            - --v=2
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+        - name: node-driver-registrar
+          image: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.13.0
+          args:
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --v=2
+          livenessProbe:
+            exec:
+              command:
+                - /csi-node-driver-registrar
+                - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+                - --mode=kubelet-registration-probe
+            initialDelaySeconds: 30
+            timeoutSeconds: 15
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/azurelustre.csi.azure.com/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+        - name: azurelustre
+          image: mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi:latest-azurelinux3
+          imagePullPolicy: Always
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "lustre_rmmod"]
+          args:
+            - "-v=5"
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+          ports:
+            - containerPort: 29763
+              name: healthz
+              protocol: TCP
+          # Reserved port for metrics
+          # - containerPort: 29765
+          #   name: metrics
+          #   protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 60
+            timeoutSeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            failureThreshold: 5
+            exec:
+              command:
+                - /app/readinessProbe.sh
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+            periodSeconds: 30
+          startupProbe:
+            failureThreshold: 120
+            exec:
+              command:
+                - /app/readinessProbe.sh
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: AZURELUSTRE_CSI_INSTALL_LUSTRE_CLIENT
+              value: "yes"
+            - name: LUSTRE_VERSION
+              value: "2.17.0"
+            - name: CLIENT_SHA_SUFFIX
+              value: "19-gbb5310f"
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /var/lib/kubelet/
+              name: mountpoint-dir
+              mountPropagation: "Bidirectional"
+            - mountPath: /etc/kubernetes/
+              name: azure-cred
+            - mountPath: /dev
+              name: host-dev
+            - mountPath: /etc/host-os-release
+              name: host-os-release
+            - mountPath: /app/custom-entrypoint
+              name: custom-entrypoint
+              readOnly: true
+          resources:
+            limits:
+              cpu: 1
+              # Azure Linux 3 needs more memory than Ubuntu (200Mi) during startup.
+              # The tdnf/RPM install runs depmod which loads the full kernel symbol
+              # map (7.5MB) and scans ~1100 modules to rebuild dependencies.
+              # Steady-state usage is ~45Mi; the spike is transient (~10s).
+              memory: 500Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/azurelustre.csi.azure.com
+            type: DirectoryOrCreate
+          name: socket-dir
+        - hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: Directory
+          name: registration-dir
+        - hostPath:
+            path: /var/lib/kubelet/
+            type: Directory
+          name: mountpoint-dir
+        - hostPath:
+            path: /etc/kubernetes/
+            type: DirectoryOrCreate
+          name: azure-cred
+        - hostPath:
+            path: /dev
+            type: Directory
+          name: host-dev
+        - hostPath:
+            path: /etc/os-release
+            type: File
+          name: host-os-release
+        - name: custom-entrypoint
+          configMap:
+            name: csi-azurelustre-entrypoint
+            defaultMode: 0755
+            optional: true

--- a/deploy/csi-azurelustre-node-noble.yaml
+++ b/deploy/csi-azurelustre-node-noble.yaml
@@ -135,9 +135,9 @@ spec:
             - name: AZURELUSTRE_CSI_INSTALL_LUSTRE_CLIENT
               value: "yes"
             - name: LUSTRE_VERSION
-              value: "2.16.1"
+              value: "2.17.0"
             - name: CLIENT_SHA_SUFFIX
-              value: "14-gbc76088"
+              value: "19-gbb5310f"
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/install-driver.sh
+++ b/deploy/install-driver.sh
@@ -119,6 +119,7 @@ kubectl apply -f "${repo}/csi-azurelustre-driver.yaml"
 kubectl apply -f "${repo}/csi-azurelustre-controller.yaml"
 kubectl apply -f "${repo}/csi-azurelustre-node-jammy.yaml"
 kubectl apply -f "${repo}/csi-azurelustre-node-noble.yaml"
+kubectl apply -f "${repo}/csi-azurelustre-node-azurelinux3.yaml"
 
 # Restart node DaemonSet pods only if the ConfigMap state changed.
 # The custom entrypoint ConfigMap is only mounted into node DaemonSets,
@@ -127,9 +128,11 @@ if [[ "${configmap_changed}" == "true" ]]; then
   echo "Custom entrypoint configuration changed, restarting node pods..."
   kubectl rollout restart daemonset csi-azurelustre-node-jammy -n kube-system
   kubectl rollout restart daemonset csi-azurelustre-node-noble -n kube-system
+  kubectl rollout restart daemonset csi-azurelustre-node-azurelinux3 -n kube-system
 fi
 
 kubectl rollout status deployment csi-azurelustre-controller -nkube-system --timeout=300s
 kubectl rollout status daemonset csi-azurelustre-node-jammy -nkube-system --timeout=1800s
 kubectl rollout status daemonset csi-azurelustre-node-noble -nkube-system --timeout=1800s
+kubectl rollout status daemonset csi-azurelustre-node-azurelinux3 -nkube-system --timeout=1800s
 echo 'Azure Lustre CSI driver installed successfully.'

--- a/deploy/uninstall-driver.sh
+++ b/deploy/uninstall-driver.sh
@@ -26,6 +26,7 @@ echo "Uninstalling Azure Lustre CSI driver, repo: ${repo} ..."
 kubectl delete -f "${repo}"/csi-azurelustre-controller.yaml --ignore-not-found
 kubectl delete -f "${repo}"/csi-azurelustre-node-jammy.yaml --ignore-not-found
 kubectl delete -f "${repo}"/csi-azurelustre-node-noble.yaml --ignore-not-found
+kubectl delete -f "${repo}"/csi-azurelustre-node-azurelinux3.yaml --ignore-not-found
 kubectl delete -f "${repo}"/csi-azurelustre-driver.yaml --ignore-not-found
 kubectl delete -f "${repo}"/rbac-csi-azurelustre-controller.yaml --ignore-not-found
 kubectl delete -f "${repo}"/rbac-csi-azurelustre-node.yaml --ignore-not-found

--- a/docs/csi-debug.md
+++ b/docs/csi-debug.md
@@ -174,7 +174,7 @@ kubectl get events --field-selector involvedObject.name=<csi-azurelustre-node-po
 
 ## OS-Specific DaemonSet Issues
 
-The Azure Lustre CSI driver uses distribution-specific DaemonSets to ensure proper Lustre client compatibility across different Ubuntu versions. Each DaemonSet targets specific node OS versions using node selectors and affinity rules.
+The Azure Lustre CSI driver uses distribution-specific DaemonSets to ensure proper Lustre client compatibility across different OS versions. Each DaemonSet targets specific node OS versions using node selectors and affinity rules.
 
 ### No CSI Driver Pods on Nodes
 
@@ -198,13 +198,14 @@ Expected output:
 NAME                                OS-SKU
 aks-nodepool1-12345678-vmss000000  Ubuntu2204
 aks-nodepool2-23456789-vmss000001  Ubuntu2404
+aks-nodepool3-34567890-vmss000002  AzureLinux3
 ```
 
 **Possible Causes:**
 
 - Node OS version doesn't match any DaemonSet selector
 - Missing or incorrect `kubernetes.azure.com/os-sku-effective` label
-- Unsupported Ubuntu version
+- Unsupported OS version (supported: Ubuntu 22.04, Ubuntu 24.04, Azure Linux 3)
 - Node labels were manually modified or are missing
 
 **Debugging Steps:**
@@ -219,6 +220,7 @@ kubectl get daemonsets -n kube-system -l app=csi-azurelustre-node
 # Check DaemonSet desired vs ready counts
 kubectl get ds -n kube-system csi-azurelustre-node-jammy
 kubectl get ds -n kube-system csi-azurelustre-node-noble
+kubectl get ds -n kube-system csi-azurelustre-node-azurelinux3
 
 # Inspect node labels in detail
 kubectl get node <node-name> --show-labels | grep os-sku-effective
@@ -254,6 +256,7 @@ kubectl get events -n kube-system --field-selector involvedObject.kind=DaemonSet
                  values:
                    - Ubuntu2204
                    - Ubuntu2004
+                   - AzureLinux3
                    - <your-custom-label-value>
    ```
 
@@ -273,9 +276,9 @@ kubectl get events -n kube-system --field-selector involvedObject.kind=DaemonSet
 
    Versions prior to v0.4.0 used a single DaemonSet without OS-specific targeting, which conflicts with the new distribution-specific architecture.
 
-3. **For unsupported Ubuntu versions:**
+3. **For unsupported OS versions:**
 
-   - Upgrade node pool to Ubuntu 22.04 or 24.04 (CVMs are supported with 20.04)
+   - Upgrade node pool to Ubuntu 22.04, Ubuntu 24.04, or Azure Linux 3
    - Create a new node pool with a supported OS version
    - Migrate workloads to supported nodes
 
@@ -286,7 +289,7 @@ kubectl get events -n kube-system --field-selector involvedObject.kind=DaemonSet
 **Symptoms:**
 
 - A single node has multiple CSI driver pods running simultaneously
-- Multiple DaemonSet pods from different flavors (jammy/noble) on the same node
+- Multiple DaemonSet pods from different flavors (jammy/noble/azurelinux3) on the same node
 - Unexpected behavior or conflicts during volume mounting
 - Resource contention on nodes
 
@@ -318,6 +321,7 @@ kubectl get node <node-name> -o jsonpath='{.metadata.labels}' | jq
 # Inspect DaemonSet node affinity rules
 kubectl get ds -n kube-system csi-azurelustre-node-jammy -o yaml | grep -A20 affinity
 kubectl get ds -n kube-system csi-azurelustre-node-noble -o yaml | grep -A20 affinity
+kubectl get ds -n kube-system csi-azurelustre-node-azurelinux3 -o yaml | grep -A20 affinity
 
 # Check for pods that should not be on a node
 kubectl describe pod -n kube-system <duplicate-pod-name> | grep -A10 "Node-Selectors\|Node Affinity"
@@ -408,6 +412,7 @@ Look for error messages like:
 # Verify image tags in DaemonSets
 kubectl get ds -n kube-system csi-azurelustre-node-jammy -o jsonpath='{.spec.template.spec.containers[?(@.name=="azurelustre")].image}'
 kubectl get ds -n kube-system csi-azurelustre-node-noble -o jsonpath='{.spec.template.spec.containers[?(@.name=="azurelustre")].image}'
+kubectl get ds -n kube-system csi-azurelustre-node-azurelinux3 -o jsonpath='{.spec.template.spec.containers[?(@.name=="azurelustre")].image}'
 
 # Check image pull secrets
 kubectl get serviceaccount -n kube-system csi-azurelustre-node-sa -o yaml
@@ -430,7 +435,7 @@ kubectl debug node/<node-name> -it --image=ubuntu -- bash
 2. **Use correct image tags:**
 
    - Ensure DaemonSet manifests use existing image tags
-   - Verify `-jammy` and `-noble` suffixes match available images
+   - Verify `-jammy`, `-noble`, and `-azurelinux3` suffixes match available images
    - Update to a known working version if needed
 
 3. **Fix network/registry access:**
@@ -459,12 +464,13 @@ kubectl get pods -n kube-system -l app=csi-azurelustre-node -o jsonpath='{range 
 # Check DaemonSet specifications
 kubectl get ds -n kube-system csi-azurelustre-node-jammy -o jsonpath='{.spec.template.spec.containers[?(@.name=="azurelustre")].image}'
 kubectl get ds -n kube-system csi-azurelustre-node-noble -o jsonpath='{.spec.template.spec.containers[?(@.name=="azurelustre")].image}'
+kubectl get ds -n kube-system csi-azurelustre-node-azurelinux3 -o jsonpath='{.spec.template.spec.containers[?(@.name=="azurelustre")].image}'
 ```
 
 **Possible Causes:**
 
 - DaemonSet update in progress (rolling update)
-- Different image tags configured for jammy vs noble DaemonSets
+- Different image tags configured for jammy, noble, or azurelinux3 DaemonSets
 - Failed DaemonSet updates leaving some pods on old versions
 - Manual pod restarts using different images
 
@@ -474,6 +480,7 @@ kubectl get ds -n kube-system csi-azurelustre-node-noble -o jsonpath='{.spec.tem
 # Check DaemonSet rollout status
 kubectl rollout status ds/csi-azurelustre-node-jammy -n kube-system
 kubectl rollout status ds/csi-azurelustre-node-noble -n kube-system
+kubectl rollout status ds/csi-azurelustre-node-azurelinux3 -n kube-system
 
 # Check for stuck rollouts
 kubectl get ds -n kube-system -l app=csi-azurelustre-node -o wide
@@ -481,6 +488,7 @@ kubectl get ds -n kube-system -l app=csi-azurelustre-node -o wide
 # Review DaemonSet update history
 kubectl rollout history ds/csi-azurelustre-node-jammy -n kube-system
 kubectl rollout history ds/csi-azurelustre-node-noble -n kube-system
+kubectl rollout history ds/csi-azurelustre-node-azurelinux3 -n kube-system
 
 # Check pod ages to identify old pods
 kubectl get pods -n kube-system -l app=csi-azurelustre-node -o custom-columns=NAME:.metadata.name,AGE:.metadata.creationTimestamp,IMAGE:.spec.containers[0].image
@@ -494,6 +502,7 @@ kubectl get pods -n kube-system -l app=csi-azurelustre-node -o custom-columns=NA
    # Wait for rollout to complete
    kubectl rollout status ds/csi-azurelustre-node-jammy -n kube-system --timeout=10m
    kubectl rollout status ds/csi-azurelustre-node-noble -n kube-system --timeout=10m
+   kubectl rollout status ds/csi-azurelustre-node-azurelinux3 -n kube-system --timeout=10m
    ```
 
 2. **Force pod recreation if stuck:**
@@ -508,6 +517,7 @@ kubectl get pods -n kube-system -l app=csi-azurelustre-node -o custom-columns=NA
    Ensure both DaemonSets use the same base version (only differing by OS suffix):
    - Jammy: `v0.4.0-jammy`
    - Noble: `v0.4.0-noble`
+   - Azure Linux 3: `v0.4.0-azurelinux3`
 
    Both should share the same version number (`v0.4.0` in this example).
 
@@ -557,6 +567,7 @@ kubectl get pods -n kube-system -l app=csi-azurelustre-node -o custom-columns=NA
 echo "Total nodes: $(kubectl get nodes --no-headers | wc -l)"
 echo "Jammy pods: $(kubectl get pods -n kube-system -l app=csi-azurelustre-node,flavor=jammy --no-headers | wc -l)"
 echo "Noble pods: $(kubectl get pods -n kube-system -l app=csi-azurelustre-node,flavor=noble --no-headers | wc -l)"
+echo "AzureLinux3 pods: $(kubectl get pods -n kube-system -l app=csi-azurelustre-node,flavor=azurelinux3 --no-headers | wc -l)"
 
 # List nodes without CSI driver pods
 comm -23 \
@@ -608,6 +619,7 @@ kubectl logs -n kube-system -l component=kube-controller-manager | grep -i daemo
    # If DaemonSet is missing or corrupted, redeploy
    kubectl apply -f deploy/csi-azurelustre-node-jammy.yaml
    kubectl apply -f deploy/csi-azurelustre-node-noble.yaml
+   kubectl apply -f deploy/csi-azurelustre-node-azurelinux3.yaml
    ```
 
 3. **Force pod creation if needed:**

--- a/docs/install-csi-driver.md
+++ b/docs/install-csi-driver.md
@@ -37,6 +37,59 @@ This document explains how to install Azure Lustre CSI driver on a kubernetes cl
     csi-azurelustre-node-g6sfx   3/3     Running   0          30s
     ```
 
+## Supported node operating systems
+
+The CSI driver runs as OS-specific node DaemonSets, each scheduled onto nodes by a `nodeSelector` or node-affinity match on the `kubernetes.azure.com/os-sku-effective` label. Only the following node OS SKUs are supported:
+
+| `os-sku-effective` | Node DaemonSet | Image flavor |
+| ------------------ | -------------- | ------------ |
+| `Ubuntu2204` | `csi-azurelustre-node-jammy` | `-jammy` |
+| `Ubuntu2004` | `csi-azurelustre-node-jammy` | `-jammy` |
+| `Ubuntu2404` | `csi-azurelustre-node-noble` | `-noble` |
+| `AzureLinux3` | `csi-azurelustre-node-azurelinux3` | `-azurelinux3` |
+
+(`Ubuntu2004` is matched by the Jammy DaemonSet as a **deprecated** bridge for legacy CVM nodes still on Ubuntu 20.04 (focal). The entrypoint allows the jammy container on a focal host but logs that this is deprecated and will be removed in a future release.)
+
+> [!IMPORTANT]
+> A node whose `os-sku-effective` value is **not** listed above matches **no** DaemonSet, so it **silently receives no CSI driver pod** (there is no catch-all DaemonSet). Lustre volumes scheduled onto that node fail to mount with no obvious driver error -- there is simply no driver present on the node. Check a node's value with:
+>
+> ```shell
+> kubectl get node <node-name> -o jsonpath='{.metadata.labels.kubernetes\.azure\.com/os-sku-effective}'
+> ```
+>
+> See the [CSI Driver Troubleshooting Guide](csi-debug.md) for `os-sku-effective` troubleshooting steps.
+
+### Karpenter and node auto-provisioning
+
+AKS clusters with [node auto-provisioning (NAP)](https://learn.microsoft.com/azure/aks/node-auto-provisioning) enabled use managed Karpenter to add nodes dynamically based on pending pods. The AKS platform does **not** enforce OS/SKU compatibility for auto-provisioned nodes, so an unconstrained `NodePool` may create nodes with an OS SKU that matches none of the DaemonSets above -- producing nodes with no CSI driver pod and silent mount failures.
+
+If you enable NAP, constrain every `NodePool` that can host Lustre workloads to the supported OS SKUs. Use the `kubernetes.azure.com/os-sku` and `kubernetes.io/arch` requirements (NAP evaluates all NodePools and works best when they are mutually exclusive):
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: lustre-supported
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        name: default            # your AKSNodeClass
+      requirements:
+        # Limit to OS SKUs the CSI driver supports.
+        - key: kubernetes.azure.com/os-sku
+          operator: In
+          values: ["Ubuntu", "AzureLinux"]
+        # The driver's Azure Linux image is amd64-only; pin amd64 unless you only
+        # run Ubuntu Noble, the one flavor that also ships an arm64 image.
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+```
+
+> [!NOTE]
+> `kubernetes.azure.com/os-sku` is coarse (`Ubuntu` or `AzureLinux`); the resulting `os-sku-effective` version (`Ubuntu2204`/`Ubuntu2404`, or `AzureLinux3`) depends on your cluster's Kubernetes/AKS version. Azure Linux resolves to **Azure Linux 3** only on AKS versions where AL3 is the default -- older clusters may provision the unsupported Azure Linux 2. Confirm every provisioned node resolves to a supported `os-sku-effective` value (`Ubuntu2204`, `Ubuntu2004`, `Ubuntu2404`, or `AzureLinux3`).
+
 ## Verifying CSI Driver Readiness for Lustre Operations
 
 Before mounting Azure Lustre filesystems, it is important to verify that the CSI driver nodes are fully initialized and ready for Lustre operations. The driver includes enhanced LNet validation that performs comprehensive readiness checks:
@@ -138,5 +191,5 @@ This deletes the ConfigMap and restarts the node pods to use the built-in entryp
 - The custom entrypoint replaces the **entire** built-in entrypoint, including Lustre client installation logic. Your custom script is responsible for any required setup before launching the CSI driver binary.
 - A good starting point for a custom entrypoint is the built-in script at `pkg/azurelustreplugin/entrypoint.sh`.
 - **Security note:** the custom entrypoint is stored in the `csi-azurelustre-entrypoint` ConfigMap in `kube-system` and is executed by a privileged container. Treat this as a code-injection path: tightly restrict RBAC for creating or updating this ConfigMap, and only use custom entrypoints in trusted/admin scenarios.
-- If you edit the ConfigMap directly (e.g., `kubectl edit configmap csi-azurelustre-entrypoint -n kube-system`), you must manually restart the node DaemonSets for changes to take effect: `kubectl rollout restart daemonset csi-azurelustre-node-jammy csi-azurelustre-node-noble -n kube-system`
+- If you edit the ConfigMap directly (e.g., `kubectl edit configmap csi-azurelustre-entrypoint -n kube-system`), you must manually restart the node DaemonSets for changes to take effect: `kubectl rollout restart daemonset csi-azurelustre-node-jammy csi-azurelustre-node-noble csi-azurelustre-node-azurelinux3 -n kube-system`
 - The uninstall script automatically cleans up the ConfigMap if it exists.

--- a/pkg/azurelustreplugin/Dockerfile.azurelinux3
+++ b/pkg/azurelustreplugin/Dockerfile.azurelinux3
@@ -12,40 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG srcImage=ubuntu:22.04
+ARG srcImage=mcr.microsoft.com/azurelinux/base/core:3.0
 FROM ${srcImage}
 
 COPY "./_output/azurelustreplugin" "/app/azurelustreplugin"
-COPY "./pkg/azurelustreplugin/useAzureAptMirror.sh" "/app/useAzureAptMirror.sh"
 COPY "./pkg/azurelustreplugin/entrypoint.sh" "/app/entrypoint.sh"
 COPY "./pkg/azurelustreplugin/start.sh" "/app/start.sh"
 COPY "./pkg/azurelustreplugin/readinessProbe.sh" "/app/readinessProbe.sh"
 
-RUN chmod +x "/app/azurelustreplugin" \
-  && chmod +x "/app/useAzureAptMirror.sh" \
-  && chmod +x "/app/entrypoint.sh" \
-  && chmod +x "/app/start.sh" \
-  && chmod +x "/app/readinessProbe.sh"
+RUN chmod +x "/app/azurelustreplugin" && chmod +x "/app/entrypoint.sh" && chmod +x "/app/start.sh" && chmod +x "/app/readinessProbe.sh"
 
-# Prefer the Ubuntu CDN; keep the Azure mirror as a lower-priority apt fallback.
-RUN /app/useAzureAptMirror.sh
-
-RUN apt-get update && \
-  apt-get upgrade -y && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    gpg curl ca-certificates iproute2 kmod && \
-  apt-get autoremove -y && \
-  apt-get clean -y && \
-  rm -rf \
-  /var/cache/debconf/* \
-  /var/lib/apt/lists/* \
-  /var/log/* \
-  /tmp/* \
-  /var/tmp/*
+RUN tdnf -y update && \
+  tdnf install -y \
+    ca-certificates \
+    curl \
+    gawk \
+    iproute \
+    kmod \
+    sed \
+    grep \
+    which && \
+  tdnf clean all && \
+  rm -rf /var/cache/tdnf/*
 
 WORKDIR "/app"
 
-LABEL maintainers="dabradley;jeffbearer;t-mialve;csmuell"
+LABEL maintainers="dabradley;csmuell"
 LABEL description="Azure Lustre CSI driver"
 
 ENTRYPOINT ["/app/start.sh", "/app/azurelustreplugin"]

--- a/pkg/azurelustreplugin/entrypoint.sh
+++ b/pkg/azurelustreplugin/entrypoint.sh
@@ -64,8 +64,29 @@ function add_net_interfaces() {
   done
 }
 
+# Detect OS family from container's os-release
+osFamily=""
+if [[ -f /etc/os-release ]]; then
+  # shellcheck disable=SC1091 # /etc/os-release is a runtime file
+  osID=$(. /etc/os-release; echo "${ID:-}")
+  if [[ "${osID}" == "azurelinux" || "${osID}" == "mariner" ]]; then
+    osFamily="azurelinux"
+  elif [[ "${osID}" == "ubuntu" || "${osID}" == "debian" ]]; then
+    osFamily="ubuntu"
+  fi
+fi
+if [[ -z "${osFamily}" ]]; then
+  echo "$(date -u) Error: Unsupported container OS: ${osID:-unknown}. Supported: ubuntu, debian, azurelinux, mariner."
+  exit 1
+fi
+echo "$(date -u) Detected OS family: ${osFamily}"
+
 # Update CA certificates to ensure HTTPS connections work
-update-ca-certificates
+if [[ "${osFamily}" == "azurelinux" ]]; then
+  update-ca-trust
+else
+  update-ca-certificates
+fi
 
 installClientPackages=${AZURELUSTRE_CSI_INSTALL_LUSTRE_CLIENT:-yes}
 echo "installClientPackages: ${installClientPackages}"
@@ -85,92 +106,189 @@ if [[ "${installClientPackages}" == "yes" ]]; then
   requiredClientSha="${CLIENT_SHA_SUFFIX}"
   echo "requiredClientSha: ${requiredClientSha}"
 
-  pkgVersion="${requiredLustreVersion}-${requiredClientSha}"
+  # Construct package version and name (OS-specific naming convention)
+  if [[ "${osFamily}" == "azurelinux" ]]; then
+    # Azure Linux RPM packages use underscores: 2.16.1_21_g153e389
+    pkgVersion="${requiredLustreVersion}_${requiredClientSha//-/_}"
+  else
+    # Ubuntu deb packages use dashes: 2.15.7-33-g79ddf99
+    pkgVersion="${requiredLustreVersion}-${requiredClientSha}"
+  fi
   echo "pkgVersion: ${pkgVersion}"
 
   pkgName="amlfs-lustre-client-${pkgVersion}"
   echo "pkgName: ${pkgName}"
 
-  # shellcheck disable=SC1091,SC2154 # /etc/os-release sets VERSION_CODENAME
-  osReleaseCodeName=$(. /etc/os-release; echo "${VERSION_CODENAME}")
-  if [[ -z "${osReleaseCodeName}" ]]; then
-    echo "Could not determine OS release codename"
-    exit 1
-  fi
-
-  # shellcheck disable=SC1091 # /etc/host-os-release exists only at runtime inside the container
-  if ! grep -q -R "${osReleaseCodeName}" /etc/host-os-release; then
-    # shellcheck disable=SC2031 # intentional: read VERSION_CODENAME in a subshell to avoid polluting the current scope
-    hostCodeName=$(. /etc/host-os-release; echo "${VERSION_CODENAME}")
-    if [[ "${hostCodeName}" == "focal" && "${osReleaseCodeName}" == "jammy" ]]; then
-      echo "Allowing jammy container on focal host, this usage is deprecated and will be removed in future"
-    else
-      echo "Incompatible host OS detected: ${hostCodeName}, expected: ${osReleaseCodeName}"
-      exit 1
-    fi
-  fi
-
   echo "$(date -u) Command line arguments: $*"
 
   kernelVersion=$(uname -r)
 
-  echo "$(date -u) Installing Lustre client packages for OS=${osReleaseCodeName}, kernel=${kernelVersion} "
+  if [[ "${osFamily}" == "azurelinux" ]]; then
+    # ----- Azure Linux path -----
 
-  ARCH=$(uname -m)
-  if [[ "${ARCH}" != "x86_64" && "${ARCH}" != "aarch64" ]]; then
-    echo "$(date -u) Error: Unsupported architecture: ${ARCH}"
-    exit 1
-  fi
-  if [[ "${ARCH}" == "x86_64" ]]; then
-    ARCH="amd64"
-  else
-    ARCH="arm64"
-  fi
-
-  # Use azure.archive.ubuntu.com mirror for package installation
-  /app/useAzureAptMirror.sh
-
-  echo "$(date -u) Adding Microsoft package repository for Lustre client modules, architecture=${ARCH}."
-  curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
-  echo "deb [arch=${ARCH}] https://packages.microsoft.com/repos/amlfs-${osReleaseCodeName}/ ${osReleaseCodeName} main" | tee /etc/apt/sources.list.d/amlfs.list
-  apt-get update
-
-  echo "$(date -u) Installing Lustre client modules: ${pkgName}=${kernelVersion}"
-
-  tries=3
-  sleep_before_retry=15
-  install_success=false
-  while [[ tries -gt 0 ]]; do
-    # grub issue
-    # https://stackoverflow.com/questions/40748363/virtual-machine-apt-get-grub-issue/40751712
-    if ! DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -o DPkg::options::="--force-confdef" -o DPkg::options::="--force-confold" \
-      "${pkgName}=${kernelVersion}"; then
-      echo "$(date -u) Error installing Lustre client modules. Will try removing existing versions"
-      # Check if lustre_rmmod is available, attempt to unload the modules if so.
-      # If modules are already uninstalled, this will still pass
-      if type lustre_rmmod >/dev/null 2>&1 && ! lustre_rmmod; then
-        echo "$(date -u) Error: Unable to unload running module. Are there still mounted Lustre filesystems on this node? Old Lustre client version may continue running."
-      fi
-      if existing_versions=$(dpkg-query --showformat=' ${Package}=${Version}' --show '*lustre-client*'); then
-        echo  "$(date -u) The following existing versions of the Lustre client are installed and will be removed:${existing_versions}"
-      fi
-      echo "$(date -u) Uninstalling existing Lustre client versions."
-      apt-get remove --purge -y '*lustre-client*' || true
-      tries=$((tries - 1))
-      sleep "${sleep_before_retry}"
-      sleep_before_retry=$((sleep_before_retry * 2))
-    else
-      install_success=true
-      break
+    # Host OS validation: check ID and major VERSION_ID
+    # shellcheck disable=SC1091 # /etc/os-release is a runtime file
+    containerVersionID=$(. /etc/os-release; echo "${VERSION_ID:-}")
+    # shellcheck disable=SC1091 # /etc/host-os-release is mounted at runtime
+    # shellcheck disable=SC2031 # intentional: read ID in a subshell to avoid polluting the current scope
+    hostID=$(. /etc/host-os-release; echo "${ID:-}")
+    # shellcheck disable=SC1091 # /etc/host-os-release is mounted at runtime
+    # shellcheck disable=SC2031 # intentional: read VERSION_ID in a subshell to avoid polluting the current scope
+    hostVersionID=$(. /etc/host-os-release; echo "${VERSION_ID:-}")
+    if [[ -z "${containerVersionID}" ]]; then
+      echo "Could not determine container OS VERSION_ID from /etc/os-release"
+      exit 1
     fi
-  done
+    if [[ -z "${hostVersionID}" ]]; then
+      echo "Could not determine host OS VERSION_ID from /etc/host-os-release"
+      exit 1
+    fi
+    if [[ "${hostID}" != "azurelinux" && "${hostID}" != "mariner" ]]; then
+      echo "Incompatible host OS detected: ${hostID}, expected: azurelinux"
+      exit 1
+    fi
+    # Compare major version (e.g., "3" from "3.0" or "3.0.20260517")
+    if [[ "${hostVersionID%%.*}" != "${containerVersionID%%.*}" ]]; then
+      echo "Incompatible host OS version: ${hostVersionID}, expected major version: ${containerVersionID%%.*}"
+      exit 1
+    fi
 
-  echo "$(date -u) Install success: ${install_success}, Tries left: ${tries}"
+    echo "$(date -u) Installing Lustre client packages for OS=azurelinux${containerVersionID%%.*}, kernel=${kernelVersion}"
 
-  if ! ${install_success}; then
-    echo "$(date -u) Error: Could not install necessary Lustre drivers for: ${pkgName}=${kernelVersion}"
+    # Repo setup: import GPG key and add yum repo
+    echo "$(date -u) Adding Microsoft package repository for Lustre client modules."
+    rpm --import https://packages.microsoft.com/keys/microsoft.asc
+    cat > /etc/yum.repos.d/amlfs.repo <<REPOEOF
+[amlfs]
+name=Azure Lustre Packages
+baseurl=https://packages.microsoft.com/yumrepos/amlfs-al${containerVersionID%%.*}
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+REPOEOF
+
+    # Transform kernel version for RPM package name:
+    # e.g. 6.6.139.1-1.azl3.x86_64 -> 6.6.139.1.1.azl3
+    kernelPkgVersion=$(echo "${kernelVersion}" | sed -e "s/\.$(uname -m)$//" | sed -re 's/[-_]/\./g')
+
+    installPkgName="${pkgName}-${kernelPkgVersion}"
+
+    echo "$(date -u) Installing Lustre client modules: ${installPkgName}"
+
+    tries=3
+    sleep_before_retry=15
+    install_success=false
+    while [[ tries -gt 0 ]]; do
+      if ! tdnf install -y --disablerepo="*" --enablerepo="amlfs" --enablerepo="azurelinux-official-base" "${installPkgName}"; then
+        echo "$(date -u) Error installing Lustre client modules. Will try removing existing versions"
+        if type lustre_rmmod >/dev/null 2>&1 && ! lustre_rmmod; then
+          echo "$(date -u) Error: Unable to unload running module. Are there still mounted Lustre filesystems on this node? Old Lustre client version may continue running."
+        fi
+        # Query exact RPM names for logging and removal
+        mapfile -t existing_pkgs < <(rpm -qa '*lustre-client*' 2>/dev/null || true)
+        if [[ ${#existing_pkgs[@]} -gt 0 ]]; then
+          echo "$(date -u) The following existing versions of the Lustre client are installed and will be removed: ${existing_pkgs[*]}"
+          echo "$(date -u) Uninstalling existing Lustre client versions."
+          tdnf remove -y "${existing_pkgs[@]}" || true
+        fi
+        tries=$((tries - 1))
+        sleep "${sleep_before_retry}"
+        sleep_before_retry=$((sleep_before_retry * 2))
+      else
+        install_success=true
+        break
+      fi
+    done
+
+    echo "$(date -u) Install success: ${install_success}, Tries left: ${tries}"
+
+    if ! ${install_success}; then
+      echo "$(date -u) Error: Could not install necessary Lustre drivers for: ${installPkgName}"
+    else
+      echo "$(date -u) Installed Lustre client packages for: ${installPkgName}"
+    fi
+
   else
-    echo "$(date -u) Installed Lustre client packages for: ${pkgName}=${kernelVersion}"
+    # ----- Ubuntu path -----
+
+    # shellcheck disable=SC1091,SC2154 # /etc/os-release sets VERSION_CODENAME
+    osReleaseCodeName=$(. /etc/os-release; echo "${VERSION_CODENAME}")
+    if [[ -z "${osReleaseCodeName}" ]]; then
+      echo "Could not determine OS release codename"
+      exit 1
+    fi
+
+    # shellcheck disable=SC1091 # /etc/host-os-release exists only at runtime inside the container
+    if ! grep -q -R "${osReleaseCodeName}" /etc/host-os-release; then
+      # shellcheck disable=SC2031 # intentional: read VERSION_CODENAME in a subshell to avoid polluting the current scope
+      hostCodeName=$(. /etc/host-os-release; echo "${VERSION_CODENAME}")
+      if [[ "${hostCodeName}" == "focal" && "${osReleaseCodeName}" == "jammy" ]]; then
+        echo "Allowing jammy container on focal host, this usage is deprecated and will be removed in future"
+      else
+        echo "Incompatible host OS detected: ${hostCodeName}, expected: ${osReleaseCodeName}"
+        exit 1
+      fi
+    fi
+
+    echo "$(date -u) Installing Lustre client packages for OS=${osReleaseCodeName}, kernel=${kernelVersion} "
+
+    ARCH=$(uname -m)
+    if [[ "${ARCH}" != "x86_64" && "${ARCH}" != "aarch64" ]]; then
+      echo "$(date -u) Error: Unsupported architecture: ${ARCH}"
+      exit 1
+    fi
+    if [[ "${ARCH}" == "x86_64" ]]; then
+      ARCH="amd64"
+    else
+      ARCH="arm64"
+    fi
+
+    # Prefer the Ubuntu CDN; keep the Azure mirror as a lower-priority apt fallback.
+    /app/useAzureAptMirror.sh
+
+    echo "$(date -u) Adding Microsoft package repository for Lustre client modules, architecture=${ARCH}."
+    curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+    echo "deb [arch=${ARCH}] https://packages.microsoft.com/repos/amlfs-${osReleaseCodeName}/ ${osReleaseCodeName} main" | tee /etc/apt/sources.list.d/amlfs.list
+    apt-get update
+
+    echo "$(date -u) Installing Lustre client modules: ${pkgName}=${kernelVersion}"
+
+    tries=3
+    sleep_before_retry=15
+    install_success=false
+    while [[ tries -gt 0 ]]; do
+      # grub issue
+      # https://stackoverflow.com/questions/40748363/virtual-machine-apt-get-grub-issue/40751712
+      if ! DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -o DPkg::options::="--force-confdef" -o DPkg::options::="--force-confold" \
+        "${pkgName}=${kernelVersion}"; then
+        echo "$(date -u) Error installing Lustre client modules. Will try removing existing versions"
+        # Check if lustre_rmmod is available, attempt to unload the modules if so.
+        # If modules are already uninstalled, this will still pass
+        if type lustre_rmmod >/dev/null 2>&1 && ! lustre_rmmod; then
+          echo "$(date -u) Error: Unable to unload running module. Are there still mounted Lustre filesystems on this node? Old Lustre client version may continue running."
+        fi
+        if existing_versions=$(dpkg-query --showformat=' ${Package}=${Version}' --show '*lustre-client*'); then
+          echo  "$(date -u) The following existing versions of the Lustre client are installed and will be removed:${existing_versions}"
+        fi
+        echo "$(date -u) Uninstalling existing Lustre client versions."
+        apt-get remove --purge -y '*lustre-client*' || true
+        tries=$((tries - 1))
+        sleep "${sleep_before_retry}"
+        sleep_before_retry=$((sleep_before_retry * 2))
+      else
+        install_success=true
+        break
+      fi
+    done
+
+    echo "$(date -u) Install success: ${install_success}, Tries left: ${tries}"
+
+    if ! ${install_success}; then
+      echo "$(date -u) Error: Could not install necessary Lustre drivers for: ${pkgName}=${kernelVersion}"
+    else
+      echo "$(date -u) Installed Lustre client packages for: ${pkgName}=${kernelVersion}"
+    fi
+
   fi
 
   init_lnet="true"

--- a/pkg/azurelustreplugin/useAzureAptMirror.sh
+++ b/pkg/azurelustreplugin/useAzureAptMirror.sh
@@ -14,20 +14,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Add Azure apt mirrors for Ubuntu packages
+# Prefer the default Ubuntu CDN mirror and fall back to the Azure regional mirror
+# only when the CDN is unreachable, via apt's priority mirror lists. Normal
+# installs stay on the fast global CDN; the Azure mirror is just insurance.
 
 set -euo pipefail
 
-ESCAPED_ARCHIVE_URL="http://archive\.ubuntu\.com/ubuntu/"
-AZURE_ARCHIVE_URL="http://azure.archive.ubuntu.com/ubuntu/"
+ARCHIVE_LIST="/etc/apt/mirrors-archive.list"
+PORTS_LIST="/etc/apt/mirrors-ports.list"
 
-ESCAPED_PORTS_URL="http://ports\.ubuntu\.com/ubuntu-ports/"
-AZURE_PORTS_URL="http://azure.ports.ubuntu.com/ubuntu-ports/"
+# priority:1 is tried first, priority:2 is the fallback. Fields are TAB-separated.
+printf 'http://archive.ubuntu.com/ubuntu/\tpriority:1\nhttp://azure.archive.ubuntu.com/ubuntu/\tpriority:2\n' > "${ARCHIVE_LIST}"
+printf 'http://ports.ubuntu.com/ubuntu-ports/\tpriority:1\nhttp://azure.ports.ubuntu.com/ubuntu-ports/\tpriority:2\n' > "${PORTS_LIST}"
 
-if [[ -f /etc/apt/sources.list.d/ubuntu.sources ]]; then
-    sed -i "s|${ESCAPED_ARCHIVE_URL}|${AZURE_ARCHIVE_URL}|g" /etc/apt/sources.list.d/ubuntu.sources
-    sed -i "s|${ESCAPED_PORTS_URL}|${AZURE_PORTS_URL}|g" /etc/apt/sources.list.d/ubuntu.sources
-elif [[ -f /etc/apt/sources.list ]]; then
-    sed -i "s|${ESCAPED_ARCHIVE_URL}|${AZURE_ARCHIVE_URL}|g" /etc/apt/sources.list
-    sed -i "s|${ESCAPED_PORTS_URL}|${AZURE_PORTS_URL}|g" /etc/apt/sources.list
-fi
+# Repoint archive/ports sources at the mirror lists (deb822 and one-line formats);
+# leave security.ubuntu.com on the CDN.
+for f in /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list; do
+  [[ -f "${f}" ]] || continue
+  sed -i \
+    -e "s|http://archive\.ubuntu\.com/ubuntu/|mirror+file:${ARCHIVE_LIST}|g" \
+    -e "s|http://ports\.ubuntu\.com/ubuntu-ports/|mirror+file:${PORTS_LIST}|g" \
+    "${f}"
+done

--- a/test/long-haul/update-test.sh
+++ b/test/long-haul/update-test.sh
@@ -29,6 +29,7 @@ function print_versions () {
 	kubectl rollout status -n kube-system deployment/csi-azurelustre-controller --timeout=600s
 	kubectl rollout status -n kube-system daemonset/csi-azurelustre-node-jammy --timeout=600s
 	kubectl rollout status -n kube-system daemonset/csi-azurelustre-node-noble --timeout=600s
+	kubectl rollout status -n kube-system daemonset/csi-azurelustre-node-azurelinux3 --timeout=600s
 
 	# shellcheck disable=SC2154 # ResourceGroup, ClusterName, PoolName are expected env vars from start-long-haul.sh
 	nodepool=$(az aks nodepool show --resource-group "${ResourceGroup}" --cluster-name "${ClusterName}" --nodepool-name "${PoolName}")
@@ -43,7 +44,17 @@ function print_versions () {
 	podName=$(kubectl get pods -n kube-system -l app=csi-azurelustre-node -o wide --field-selector=status.phase=Running --sort-by=.metadata.creationTimestamp | grep "${PoolName}" | awk '{print $1}' | head -n 1)
 	echo "Get kernel version and Lustre module version from pod ${podName}"
 	kernelVersion=$(kubectl exec -n kube-system -it "${podName}" -c azurelustre -- /bin/bash -c "uname -r")
-	module=$(kubectl exec -n kube-system -it "${podName}" -c azurelustre -- /bin/bash -c "dpkg-query -f '\${Package}|\${Version}' -W kmod-lustre-client-*")
+	# Detect OS family to use the right package query
+	osID=$(kubectl exec -n kube-system -it "${podName}" -c azurelustre -- /bin/bash -c ". /etc/os-release; echo \${ID:-}")
+	osID=$(echo "${osID}" | tr -d '[:space:]')
+	if [[ "${osID}" == "azurelinux" || "${osID}" == "mariner" ]]; then
+		# Prefer the kmod module package (parity with the Ubuntu branch); fall back to
+		# the amlfs metapackage only if no kmod package is installed. Querying both
+		# patterns together would let head -n 1 nondeterministically pick the metapackage.
+		module=$(kubectl exec -n kube-system -it "${podName}" -c azurelustre -- /bin/bash -c "m=\$(rpm -qa 'kmod-lustre-client-*' --queryformat '%{NAME}|%{VERSION}\n' | head -n 1); [[ -z \"\${m}\" ]] && m=\$(rpm -qa 'amlfs-lustre-client-*' --queryformat '%{NAME}|%{VERSION}\n' | head -n 1); echo \"\${m}\"")
+	else
+		module=$(kubectl exec -n kube-system -it "${podName}" -c azurelustre -- /bin/bash -c "dpkg-query -f '\${Package}|\${Version}' -W kmod-lustre-client-*")
+	fi
 	modulePkgName=${module%|*}
 	modulePkgVersion=${module#*|}
 
@@ -101,6 +112,7 @@ print_logs_title "Start and verify sample workload"
 kubectl rollout status -n kube-system deployment/csi-azurelustre-controller --timeout=600s
 kubectl rollout status -n kube-system daemonset/csi-azurelustre-node-jammy --timeout=600s
 kubectl rollout status -n kube-system daemonset/csi-azurelustre-node-noble --timeout=600s
+kubectl rollout status -n kube-system daemonset/csi-azurelustre-node-azurelinux3 --timeout=600s
 
 start_sample_workload
 

--- a/test/long-haul/utils.sh
+++ b/test/long-haul/utils.sh
@@ -62,6 +62,7 @@ reset_csi_driver () {
     kubectl delete -f "${REPO_ROOT_PATH}"/deploy/csi-azurelustre-controller.yaml --ignore-not-found
     kubectl delete -f "${REPO_ROOT_PATH}"/deploy/csi-azurelustre-node-jammy.yaml --ignore-not-found
     kubectl delete -f "${REPO_ROOT_PATH}"/deploy/csi-azurelustre-node-noble.yaml --ignore-not-found
+    kubectl delete -f "${REPO_ROOT_PATH}"/deploy/csi-azurelustre-node-azurelinux3.yaml --ignore-not-found
     kubectl wait pod -n kube-system --for=delete --selector='app in (csi-azurelustre-controller,csi-azurelustre-node)' --timeout=600s
 
 
@@ -77,11 +78,13 @@ reset_csi_driver () {
     kubectl apply -f "${REPO_ROOT_PATH}"/deploy/csi-azurelustre-controller.yaml
     kubectl apply -f "${REPO_ROOT_PATH}"/deploy/csi-azurelustre-node-jammy.yaml
     kubectl apply -f "${REPO_ROOT_PATH}"/deploy/csi-azurelustre-node-noble.yaml
+    kubectl apply -f "${REPO_ROOT_PATH}"/deploy/csi-azurelustre-node-azurelinux3.yaml
 
     # Wait for new generation of pods to roll out (avoids racing on stale pod snapshots)
     kubectl rollout status -n kube-system deployment/csi-azurelustre-controller --timeout=600s
     kubectl rollout status -n kube-system daemonset/csi-azurelustre-node-jammy --timeout=600s
     kubectl rollout status -n kube-system daemonset/csi-azurelustre-node-noble --timeout=600s
+    kubectl rollout status -n kube-system daemonset/csi-azurelustre-node-azurelinux3 --timeout=600s
 }
 
 get_worker_node_num () {


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

Adds Azure Linux 3 (Mariner) as a supported node OS flavor for the Azure Lustre
CSI driver, alongside the existing Ubuntu jammy/noble flavors.

- New `azurelinux3` build flavor: `Dockerfile.azurelinux3` (based on
  `mcr.microsoft.com/azurelinux/base/core:3.0`) and a `DOCKERFILE_<flavor>`
  override hook in the Makefile flavor system.
- `entrypoint.sh` now detects the host OS family and branches between a
  `tdnf`-based Azure Linux install path and the pre-existing `apt`-based Ubuntu
  path. The Ubuntu path is unchanged.
- The Azure Linux path installs the Lustre client kmod pinned to the running
  kernel via an RPM `Name-Version` spec (no hardcoded release suffix), so nodes
  keep installing correctly after Microsoft rebuilds the kmod and bumps the
  release.
- New `csi-azurelustre-node-azurelinux3` DaemonSet, wired into
  `install-driver.sh` / `uninstall-driver.sh`, scheduled via the
  `os-sku-effective: AzureLinux3` node label, with a 500Mi memory limit sized
  for the depmod post-install spike.
- Trivy workflow, distribution-specific README, and csi-debug docs updated for
  the new flavor.

## Which issue(s) this PR fixes

Fixes #

## Requirements

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] includes documentation
- [ ] adds unit tests
- [x] tested upgrade from previous version

## Testing
Validated end-to-end on a live AKS cluster (TIP5) with three node pools running
concurrently -- AzureLinux3, Ubuntu 22.04 (jammy), and Ubuntu 24.04 (noble):

- All three node DaemonSets reach 3/3 Ready; `lustre` + `lnet` modules load on
  every flavor.
- A forced clean Azure Linux 3 reinstall exercised the new `Name-Version` RPM
  spec, which resolved to the exact running kernel (`6.6.138.1.1.azl3`) and let
  the release float.
- Cross-OS I/O verified on a shared RWX PVC: files written from any flavor are
  read back from the others.

## Misc

A follow-up will address known readability/maintainability items (extracting a
shared install-retry helper to de-duplicate the AL3 and Ubuntu paths, I see a universal installer in the future).

## Release note

```text
Add Azure Linux 3 (Mariner) support for the Azure Lustre CSI driver node plugin.
```
