### PR TITLE
refactor(test): run integration_dalec csc client as a sidecar container

### DIFF
--- a/test/integration_dalec/Dockerfile.csc
+++ b/test/integration_dalec/Dockerfile.csc
@@ -1,0 +1,16 @@
+# Test-only image for the integration_dalec harness.
+#
+# It carries the `csc` CSI client (github.com/dell/gocsi/csc) plus a POSIX
+# shell + coreutils/awk/sed so run_integration_test.sh can drive the driver
+# under test over a shared CSI socket. This image is NEVER shipped: it is built
+# and loaded into the local KIND cluster purely to run the integration test,
+# which keeps the distro driver images (azlinux3/jammy/noble) unmodified and
+# free of any test tooling or package managers.
+FROM golang:1.25 AS build
+ARG CSC_VERSION=v1.13.0
+RUN GOBIN=/out go install github.com/dell/gocsi/csc@${CSC_VERSION}
+
+FROM debian:stable-slim
+# bash, sed, mawk, coreutils ship in debian-slim; csc is the only addition.
+COPY --from=build /out/csc /usr/local/bin/csc
+ENTRYPOINT ["/bin/bash"]

--- a/test/integration_dalec/README.md
+++ b/test/integration_dalec/README.md
@@ -1,0 +1,143 @@
+# integration_dalec -- DALEC image integration test
+
+This directory holds the integration test that the
+[dalec-build-defs](https://github.com/Azure/dalec-build-defs) pipeline runs
+against the DALEC-built `azurelustre-csi` container images (the `jammy`,
+`noble`, and `azurelinux3` variants).
+
+It stands up a local [KIND](https://kind.sigs.k8s.io/) cluster, runs the driver
+image under test, and exercises the CSI API with the
+[`csc`](https://github.com/dell/gocsi) client.
+
+## How it works (sidecar design)
+
+The test runs a single Pod with **two containers** that share the CSI socket
+through an `emptyDir` volume mounted at `/csi`:
+
+```
+        Pod: azurelustre-integration-dalec
+ +-----------------------------------------------+
+ |  driver container         tester container    |
+ |  (image under test)       (csc image)         |
+ |  plugin --endpoint  ->    csc --endpoint      |
+ |                    \     /                    |
+ |      emptyDir "socket-dir" -> /csi/csi.sock   |  <- shared socket
+ +-----------------------------------------------+
+        configMap -> /test/run_integration_test.sh (mounted into tester)
+```
+
+- **`driver`** runs *only* the plugin from the image under test
+  (`/app/azurelustreplugin`). The shipped image is used **as-is** -- no test
+  tooling is installed into it.
+- **`tester`** is a small test-only image (`Dockerfile.csc`) that carries the
+  `csc` client plus a shell. It runs `run_integration_test.sh`, which waits for
+  the driver's socket and drives the full volume lifecycle.
+
+Because `csc` lives in its own container, the **same harness works for every
+distro variant** -- including the distroless Azure Linux 3 image, which has no
+package manager or Go toolchain. The `csc` image is never shipped.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `Dockerfile.csc` | Builds the test-only `csc` sidecar image (never shipped). |
+| `run_integration_test.sh` | Runs **inside** the `tester` container: waits for the socket, runs the `csc` create/validate/publish/stats/unpublish/delete/identity/get-info sequence. |
+| `integration_dalec_aks.yaml.template` | Two-container Pod (`driver` + `tester`) sharing the CSI socket. |
+| `setup_integration_test_dalec.sh` | Orchestrator: creates the configmap, applies the Pod, waits for the `tester` container to finish, and exits with its exit code. |
+
+## Running manually
+
+### Prerequisites
+
+`docker` (running), `kubectl`, `envsubst` (gettext), and `kind`.
+
+Install `kind` to a user-writable directory (no `sudo`; works on WSL):
+
+```bash
+mkdir -p ~/.local/bin
+curl -sLo ~/.local/bin/kind \
+  https://github.com/kubernetes-sigs/kind/releases/download/v0.27.0/kind-linux-amd64
+chmod +x ~/.local/bin/kind
+kind --version
+```
+
+The `v0.27.0` above is pinned for convenience; CI's `get-kind.sh` pins the
+authoritative version.
+
+> CI installs `kind` via `dalec-build-defs/testing/scripts/get-kind.sh`. That
+> script is meant for CI -- it requires `ARCH` to be set and uses `sudo` to
+> install to `/usr/local/bin` -- so for a manual run prefer the `curl` command
+> above.
+
+### Steps
+
+The **driver image** is produced by the DALEC specs in `dalec-build-defs`; the
+steps below assume you have that repo checked out. Adjust the two paths.
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"          # wherever kind is installed
+DALEC=/path/to/dalec-build-defs
+CSI=/path/to/azurelustre-csi-driver           # this repo
+CLUSTER_NAME=azurelustre-csi-test
+```
+
+### 1. Build the driver image under test
+
+Azure Linux 3:
+
+```bash
+cd "$DALEC"
+export REGISTRY=upstream.azurecr.io REPO=oss/v2/kubernetes-csi TAG=0.5.0-azurelinux3
+export IMAGE_NAME="${REGISTRY}/${REPO}/azurelustre-csi:${TAG}"
+docker buildx build --target azlinux3/container --build-arg DALEC_SKIP_SIGNING=1 \
+  -f specs/kubernetes-csi-azurelustre/azurelustre-csi-0.5.0-azurelinux3.yml \
+  -t "$IMAGE_NAME" --load .
+```
+
+For the deb variants use `--target noble/testing/container` (or
+`jammy/testing/container`) and the matching spec file.
+
+### 2. Build the csc sidecar image
+
+```bash
+export CSC_IMAGE_NAME="azurelustre-csi-test/csc:local"
+docker build -f "$CSI/test/integration_dalec/Dockerfile.csc" \
+  -t "$CSC_IMAGE_NAME" "$CSI/test/integration_dalec"
+```
+
+### 3. Create the cluster and load both images
+
+```bash
+kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
+kind create cluster --name "$CLUSTER_NAME"
+kind load docker-image "$IMAGE_NAME"     --name "$CLUSTER_NAME"
+kind load docker-image "$CSC_IMAGE_NAME" --name "$CLUSTER_NAME"
+```
+
+### 4. Run the harness
+
+```bash
+cd "$CSI/test/integration_dalec"
+bash ./setup_integration_test_dalec.sh
+echo "exit: $?"     # 0 = pass
+```
+
+A passing run ends with `Integration test is completed.` and `Result: 0`. On
+failure the orchestrator dumps the `driver` container logs for debugging.
+
+### 5. Tear down
+
+```bash
+kind delete cluster --name "$CLUSTER_NAME"
+```
+
+## Notes
+
+- The driver runs with `--enable-azurelustre-mock-mount` and
+  `--enable-azurelustre-mock-dyn-prov`. The mock flags let the driver serve the
+  CSI API without a real Azure Lustre filesystem or an
+  `/etc/kubernetes/azure.json` cloud config, so the test needs no live AMLFS.
+- The `driver` container runs for the life of the Pod (it is a server), so the
+  orchestrator waits on the **`tester`** container's exit code rather than on
+  the whole Pod terminating.

--- a/test/integration_dalec/README.md
+++ b/test/integration_dalec/README.md
@@ -14,7 +14,7 @@ image under test, and exercises the CSI API with the
 The test runs a single Pod with **two containers** that share the CSI socket
 through an `emptyDir` volume mounted at `/csi`:
 
-```
+```text
         Pod: azurelustre-integration-dalec
  +-----------------------------------------------+
  |  driver container         tester container    |
@@ -40,7 +40,7 @@ package manager or Go toolchain. The `csc` image is never shipped.
 ## Files
 
 | File | Purpose |
-|---|---|
+| --- | --- |
 | `Dockerfile.csc` | Builds the test-only `csc` sidecar image (never shipped). |
 | `run_integration_test.sh` | Runs **inside** the `tester` container: waits for the socket, runs the `csc` create/validate/publish/stats/unpublish/delete/identity/get-info sequence. |
 | `integration_dalec_aks.yaml.template` | Two-container Pod (`driver` + `tester`) sharing the CSI socket. |

--- a/test/integration_dalec/integration_dalec_aks.yaml.template
+++ b/test/integration_dalec/integration_dalec_aks.yaml.template
@@ -4,17 +4,40 @@ kind: Pod
 metadata:
   name: azurelustre-integration-dalec
 spec:
+  # The driver under test and the test client run as two containers sharing the
+  # CSI socket via an emptyDir. The driver image (${IMAGE_NAME}) is used exactly
+  # as shipped -- it runs only the plugin. The tester image (${CSC_IMAGE_NAME})
+  # carries the csc client and runs the integration script. This decoupling lets
+  # one harness cover jammy/noble/azlinux3 without installing any test tooling
+  # into the distro images (the Azure Linux 3 image is distroless).
   containers:
-    - name: azurelustre-integration-dalec
+    - name: driver
       image: ${IMAGE_NAME}
+      imagePullPolicy: IfNotPresent
+      command:
+        - /app/azurelustreplugin
+        - --v=5
+        - --endpoint=unix:///csi/csi.sock
+        - --enable-azurelustre-mock-mount
+        - --enable-azurelustre-mock-dyn-prov
+        - --nodeid=integrationtestnode
+      volumeMounts:
+        - name: socket-dir
+          mountPath: /csi
+    - name: tester
+      image: ${CSC_IMAGE_NAME}
       imagePullPolicy: IfNotPresent
       command: ["bash", "/test/run_integration_test.sh"]
       volumeMounts:
+        - name: socket-dir
+          mountPath: /csi
         - name: script-volume
           mountPath: /test/run_integration_test.sh
           subPath: run_integration_test.sh
           readOnly: true
   volumes:
+    - name: socket-dir
+      emptyDir: {}
     - name: script-volume
       configMap:
         name: integration-dalec-script

--- a/test/integration_dalec/run_integration_test.sh
+++ b/test/integration_dalec/run_integration_test.sh
@@ -14,6 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script runs in the "tester" sidecar container, which carries a prebuilt
+# `csc` client. The driver under test runs in a separate container in the same
+# pod; the two share the CSI socket via an emptyDir mounted at /csi. This keeps
+# the shipped driver image (azlinux3/jammy/noble) unmodified -- no package
+# manager, Go toolchain, or csc is installed into it -- so the same harness
+# works across all distro variants, including the distroless Azure Linux 3 image.
+
 set -o xtrace
 set -o errexit
 set -o pipefail
@@ -28,35 +35,12 @@ readonly lustre_fs_ip=1.2.3.4
 
 mkdir -p "${target_path}"
 
-apt-get update
-apt-get install -y --no-install-recommends kmod wget git ca-certificates lsb-release gpg curl
-update-ca-certificates
+# csc is baked into this sidecar image; no install step is required.
+csc --version || true
 
-curl -sSLf https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
-echo "deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/ubuntu/22.04/prod jammy main" | tee /etc/apt/sources.list.d/amlfs.list
-apt-get update
-
-apt install -y msft-golang
-
-go version
-
-echo "$(date -u) Enabled Lustre client kernel modules."
-
-echo "$(date -u) Entering Lustre CSI driver"
-
-echo "$(date -u) install csc"
-go install github.com/dell/gocsi/csc@v1.13.0
-export PATH=${PATH}:/root/go/bin # add csc to path
-
-mkdir /csi
-echo "$(date -u) Exiting Lustre CSI driver"
-nohup /app/azurelustreplugin --v=5 \
-              --endpoint="${endpoint}" \
-              --enable-azurelustre-mock-mount \
-	      --nodeid=integrationtestnode >csi.log 2>&1 &
-
-# Wait for the CSI socket to be created
-for _ in $(seq 1 30); do
+# Wait for the driver container to create the CSI socket on the shared volume.
+echo "$(date -u) Waiting for CSI socket ${endpoint}"
+for _ in $(seq 1 60); do
     if [[ -S /csi/csi.sock ]]; then
         break
     fi
@@ -64,11 +48,11 @@ for _ in $(seq 1 30); do
 done
 
 if [[ ! -S /csi/csi.sock ]]; then
-    echo "ERROR: CSI socket /csi/csi.sock did not appear within 30s" >&2
+    echo "ERROR: CSI socket /csi/csi.sock did not appear within 60s" >&2
     exit 1
 fi
 
-echo "====: $(date -u) Exiting integration test"
+echo "====: $(date -u) Starting integration test"
 export X_CSI_DEBUG=true
 echo "====: $(date -u) Create volume test:"
 value="$(csc controller new --endpoint "${endpoint}" \
@@ -109,4 +93,4 @@ csc identity plugin-info --endpoint "${endpoint}"
 echo "====: $(date -u) Node get info test:"
 csc node get-info --endpoint "${endpoint}"
 
-echo "$(date -u) Integration test on aks is completed."
+echo "$(date -u) Integration test is completed."

--- a/test/integration_dalec/run_integration_test.sh
+++ b/test/integration_dalec/run_integration_test.sh
@@ -35,8 +35,9 @@ readonly lustre_fs_ip=1.2.3.4
 
 mkdir -p "${target_path}"
 
-# csc is baked into this sidecar image; no install step is required.
-csc --version || true
+# csc is baked into this sidecar image. Verify it is present and executable up
+# front so a broken/missing image fails immediately with a clear message
+command -v csc >/dev/null 2>&1 || { echo "ERROR: csc not found in tester image" >&2; exit 1; }
 
 # Wait for the driver container to create the CSI socket on the shared volume.
 echo "$(date -u) Waiting for CSI socket ${endpoint}"

--- a/test/integration_dalec/setup_integration_test_dalec.sh
+++ b/test/integration_dalec/setup_integration_test_dalec.sh
@@ -40,10 +40,28 @@ envsubst < integration_dalec_aks.yaml.template | kubectl apply -f -
 
 # The driver container runs for the life of the pod, so we cannot wait on the
 # whole pod terminating. Instead wait for the "tester" container to finish and
-# read its exit code. The driver "tester" container names must match the pod
-# template.
+# read its exit code. The "driver" and "tester" container names must match the
+# pod template.
 tester_container=tester
 driver_container=driver
+
+# Container waiting reasons that will never resolve on their own (bad/missing
+# image, crash loop, misconfig). If either container hits one of these, fail
+# fast instead of waiting out the full timeout.
+fatal_waiting_reason() {
+  local reason
+  for c in "${tester_container}" "${driver_container}"; do
+    reason=$(kubectl get pod "${pod}" \
+      -o=jsonpath="{.status.containerStatuses[?(@.name==\"${c}\")].state.waiting.reason}" 2>/dev/null || echo "")
+    case "${reason}" in
+      ImagePullBackOff|ErrImagePull|InvalidImageName|CrashLoopBackOff|CreateContainerConfigError|CreateContainerError)
+        echo "ERROR: ${c} container is stuck in ${reason}; aborting." >&2
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
 
 echo "Waiting for the ${tester_container} container to complete..."
 result=""
@@ -56,6 +74,11 @@ for _ in $(seq 1 300); do
     break
   fi
   if [[ "${phase}" == "Failed" ]]; then
+    break
+  fi
+  # Catch image-pull/scheduling/crash failures that leave the pod Pending or
+  # Running (not Failed) so we don't block for the whole timeout window.
+  if fatal_waiting_reason; then
     break
   fi
   sleep 2

--- a/test/integration_dalec/setup_integration_test_dalec.sh
+++ b/test/integration_dalec/setup_integration_test_dalec.sh
@@ -58,6 +58,10 @@ fatal_waiting_reason() {
         echo "ERROR: ${c} container is stuck in ${reason}; aborting." >&2
         return 0
         ;;
+      *)
+        # Empty or transient reason (ContainerCreating, PodInitializing, etc.):
+        # not fatal, keep waiting.
+        ;;
     esac
   done
   return 1

--- a/test/integration_dalec/setup_integration_test_dalec.sh
+++ b/test/integration_dalec/setup_integration_test_dalec.sh
@@ -16,10 +16,16 @@
 
 set -euox pipefail
 
-# Ensure required variables are set
-: "${IMAGE_NAME:?Required variable IMAGE_NAME is not set}" # Ex: upstream.azurecr.io/oss/v2/kubernetes-csi/azurelustre-csi:latest-jammy
+# IMAGE_NAME is the driver image under test (the DALEC-built distro variant).
+# CSC_IMAGE_NAME is the test-only sidecar carrying the csc client.
+: "${IMAGE_NAME:?Required variable IMAGE_NAME is not set}"       # Ex: upstream.azurecr.io/oss/v2/kubernetes-csi/azurelustre-csi:latest-azurelinux3
+: "${CSC_IMAGE_NAME:?Required variable CSC_IMAGE_NAME is not set}" # Ex: azurelustre-csi-test/csc:local
 
 echo "IMAGE_NAME: ${IMAGE_NAME}"
+echo "CSC_IMAGE_NAME: ${CSC_IMAGE_NAME}"
+
+pod=azurelustre-integration-dalec
+readonly pod
 
 # Create a configmap for the integration test script
 kubectl delete configmap integration-dalec-script --ignore-not-found
@@ -32,16 +38,31 @@ envsubst < integration_dalec_aks.yaml.template
 envsubst < integration_dalec_aks.yaml.template | kubectl delete -f - --ignore-not-found
 envsubst < integration_dalec_aks.yaml.template | kubectl apply -f -
 
-# Now running - wait for completion!
-pod=azurelustre-integration-dalec
-kubectl wait --for=condition=Ready "pod/${pod}" --timeout=300s
-kubectl wait --for=condition=Ready=false "pod/${pod}" --timeout=300s
-# Grab Result. Filter by container name so a future sidecar injection (logging,
-# service mesh, etc.) doesn't make the jsonpath return multiple exit codes and
-# break `exit "${result}"` with "numeric argument required".
-result=$(kubectl get pod "${pod}" -o=jsonpath="{.status.containerStatuses[?(@.name==\"${pod}\")].state.terminated.exitCode}")
-kubectl logs "${pod}"
-echo "Result: ${result}"
+# The driver container runs for the life of the pod, so we cannot wait on the
+# whole pod terminating. Instead wait for the "tester" container to finish and
+# read its exit code. The driver "tester" container names must match the pod
+# template.
+tester_container=tester
+driver_container=driver
+
+echo "Waiting for the ${tester_container} container to complete..."
+result=""
+for _ in $(seq 1 300); do
+  # Surface pod-level scheduling/image failures early with a clear message.
+  phase=$(kubectl get pod "${pod}" -o=jsonpath="{.status.phase}" 2>/dev/null || echo "")
+  result=$(kubectl get pod "${pod}" \
+    -o=jsonpath="{.status.containerStatuses[?(@.name==\"${tester_container}\")].state.terminated.exitCode}" 2>/dev/null || echo "")
+  if [[ -n "${result}" ]]; then
+    break
+  fi
+  if [[ "${phase}" == "Failed" ]]; then
+    break
+  fi
+  sleep 2
+done
+
+echo "===== ${tester_container} logs ====="
+kubectl logs "${pod}" -c "${tester_container}" || true
 
 # Validate result is a non-empty integer before exiting. An empty or non-numeric
 # value (container never terminated, name mismatch, jsonpath miss) would cause
@@ -50,8 +71,17 @@ echo "Result: ${result}"
 # normally report 0-255, but be permissive).
 if [[ ! "${result}" =~ ^-?[0-9]+$ ]]; then
   echo "ERROR: integration test container did not produce a valid exit code." >&2
-  echo "Dumping pod state for debugging:" >&2
+  echo "===== ${driver_container} logs (for debugging) =====" >&2
+  kubectl logs "${pod}" -c "${driver_container}" >&2 || true
+  echo "===== pod state (for debugging) =====" >&2
   kubectl get pod "${pod}" -o yaml >&2 || true
   exit 1
 fi
+
+echo "Result: ${result}"
+if [[ "${result}" -ne 0 ]]; then
+  echo "===== ${driver_container} logs (test failed) =====" >&2
+  kubectl logs "${pod}" -c "${driver_container}" >&2 || true
+fi
+
 exit "${result}"


### PR DESCRIPTION
## What type of PR is this?

/kind test
/kind cleanup
/kind documentation

## What this PR does / why we need it

Reworks the `test/integration_dalec` harness so the `csc` CSI client runs in
its own **sidecar container** next to the driver, instead of being installed
into the driver image under test.

Previously the harness assumed the driver image carried `csc` plus a shell.
That does not hold for the DALEC-built distro images -- especially the
distroless Azure Linux 3 image, which has no package manager or Go toolchain.
This change makes one harness work for every distro variant without modifying
the shipped images.

How it works: a single Pod runs two containers that share the CSI socket via an
`emptyDir` mounted at `/csi`:

- `driver` -- the image under test, running only `/app/azurelustreplugin`. The
  shipped image is used as-is; no test tooling is added.
- `tester` -- a small test-only image (`Dockerfile.csc`) carrying the `csc`
  client (github.com/dell/gocsi/csc) plus a shell. It runs
  `run_integration_test.sh`, which waits for the driver socket and drives the
  full create/validate/publish/stats/unpublish/delete/identity/get-info
  sequence. This image is never shipped.

Changes:

- `Dockerfile.csc` (new) -- builds the test-only `csc` sidecar image.
- `integration_dalec_aks.yaml.template` -- two-container Pod (`driver` +
  `tester`) sharing the CSI socket through an `emptyDir`.
- `setup_integration_test_dalec.sh` -- creates the configmap, applies the Pod,
  and waits on the `tester` container's exit code (the `driver` container runs
  for the life of the Pod, so we cannot wait on the whole Pod terminating). On
  failure it dumps the `driver` logs for debugging.
- `run_integration_test.sh` -- runs inside the `tester` container.
- `README.md` (new) -- documents the sidecar design, files, and manual run
  steps.

This is the CSI-side dependency for the corresponding
`Azure/dalec-build-defs` spec PR, whose `test.sh` clones this repo and builds
`Dockerfile.csc`; that build fails until this lands on `development`.

## Which issue(s) this PR fixes

Fixes #

## Requirements

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [x] includes documentation (new `test/integration_dalec/README.md`)
- [ ] adds unit tests (N/A -- integration test harness change, no production code)
- [ ] tested upgrade from previous version (N/A)

## notes for reviewer

- No production/driver code changes -- this only touches
  `test/integration_dalec/`. The shipped driver images are unchanged.
- The `csc` image is test-only and never pushed to a registry; it is built and
  loaded into the local KIND cluster at test time.
- The driver runs with `--enable-azurelustre-mock-mount` and
  `--enable-azurelustre-mock-dyn-prov`, so the test needs no live Azure Lustre
  filesystem or `azure.json` cloud config.
