### PR TITLE
Fix case-sensitive subnet ID comparison in checkSubnetAddresses

### DIFF
--- a/pkg/azurelustre/dynamic_provisioning.go
+++ b/pkg/azurelustre/dynamic_provisioning.go
@@ -463,7 +463,10 @@ func (d *DynamicProvisioner) checkSubnetAddresses(ctx context.Context, vnetResou
 		}
 
 		for _, usageValue := range page.Value {
-			if *usageValue.ID == subnetID {
+			// Azure resource group names are case-insensitive, but different ARM
+			// endpoints may echo back different casing for the same resource ID,
+			// so compare case-insensitively to avoid false "subnet not found" errors.
+			if strings.EqualFold(*usageValue.ID, subnetID) {
 				usedIPs := *usageValue.CurrentValue
 				limitIPs := *usageValue.Limit
 				availableIPs := int(limitIPs) - int(usedIPs)

--- a/pkg/azurelustre/dynamic_provisioning_test.go
+++ b/pkg/azurelustre/dynamic_provisioning_test.go
@@ -48,22 +48,29 @@ type mockAmlfsRecorder struct {
 }
 
 const (
-	expectedMgsAddress                          = "127.0.0.3"
-	expectedResourceGroupName                   = "fake-resource-group"
-	expectedAmlFilesystemName                   = "fake-amlfs"
-	expectedLocation                            = "fake-location"
-	expectedAmlFilesystemSubnetSize             = 24
-	expectedUsedIPCount                         = 10
-	expectedFullIPCount                         = 256
-	expectedTotalIPCount                        = 256
-	expectedSku                                 = "fake-sku"
-	otherSkuForLocation                         = "other-sku-for-location"
-	expectedClusterSize                         = 48
-	expectedSkuIncrement                        = "4"
-	expectedSkuMaximum                          = "128"
-	expectedVnetName                            = "fake-vnet"
-	expectedAmlFilesystemSubnetName             = "fake-subnet-name"
-	expectedAmlFilesystemSubnetID               = "fake-subnet-id"
+	expectedMgsAddress              = "127.0.0.3"
+	expectedResourceGroupName       = "fake-resource-group"
+	expectedAmlFilesystemName       = "fake-amlfs"
+	expectedLocation                = "fake-location"
+	expectedAmlFilesystemSubnetSize = 24
+	expectedUsedIPCount             = 10
+	expectedFullIPCount             = 256
+	expectedTotalIPCount            = 256
+	expectedSku                     = "fake-sku"
+	otherSkuForLocation             = "other-sku-for-location"
+	expectedClusterSize             = 48
+	expectedSkuIncrement            = "4"
+	expectedSkuMaximum              = "128"
+	expectedVnetName                = "fake-vnet"
+	expectedAmlFilesystemSubnetName = "fake-subnet-name"
+	expectedAmlFilesystemSubnetID   = "fake-subnet-id"
+	// caseMismatchAmlFilesystemSubnetID is the same subnet ID as
+	// expectedAmlFilesystemSubnetID but with different casing, used to
+	// simulate the ARM VNet ListUsage API returning a differently-cased
+	// resource group segment than the one the driver builds itself
+	// (see GitHub issue #290).
+	caseMismatchAmlFilesystemSubnetID           = "FAKE-SUBNET-ID"
+	caseMismatchVnetName                        = "case-mismatch-vnet"
 	fullVnetName                                = "full-vnet"
 	invalidSku                                  = "invalid-sku"
 	missingAmlFilesystemSubnetID                = "missing-subnet-id"
@@ -371,6 +378,21 @@ func newFakeVnetServer(_ *testing.T, recorder *mockAmlfsRecorder) *networkfake.V
 			resp.AddPage(http.StatusOK, armnetwork.VirtualNetworksClientListUsageResponse{
 				VirtualNetworkListUsageResult: armnetwork.VirtualNetworkListUsageResult{
 					Value: []*armnetwork.VirtualNetworkUsage{},
+				},
+			}, nil)
+			return resp
+		}
+
+		if vnetName == caseMismatchVnetName {
+			resp.AddPage(http.StatusOK, armnetwork.VirtualNetworksClientListUsageResponse{
+				VirtualNetworkListUsageResult: armnetwork.VirtualNetworkListUsageResult{
+					Value: []*armnetwork.VirtualNetworkUsage{
+						{
+							ID:           to.Ptr(string(caseMismatchAmlFilesystemSubnetID)),
+							CurrentValue: to.Ptr(float64(expectedUsedIPCount)),
+							Limit:        to.Ptr(float64(expectedTotalIPCount)),
+						},
+					},
 				},
 			}, nil)
 			return resp
@@ -1369,6 +1391,25 @@ func TestDynamicProvisioner_CheckSubnetCapacity_FullVnet(t *testing.T) {
 	hasSufficientCapacity, err := dynamicProvisioner.CheckSubnetCapacity(context.Background(), subnetInfo, expectedSku, expectedClusterSize)
 	require.NoError(t, err)
 	assert.False(t, hasSufficientCapacity)
+}
+
+// TestDynamicProvisioner_CheckSubnetCapacity_Success_CaseInsensitiveSubnetIDMatch
+// covers GitHub issue #290: the subnet ID the driver builds locally must
+// still match the subnet ID the ARM VirtualNetworks ListUsage API returns
+// even if that API echoes back different casing, since
+// Azure resource group names are case-insensitive.
+func TestDynamicProvisioner_CheckSubnetCapacity_Success_CaseInsensitiveSubnetIDMatch(t *testing.T) {
+	recorder := newMockAmlfsRecorder([]string{})
+	dynamicProvisioner := newTestDynamicProvisioner(t, recorder)
+
+	subnetInfo := buildExpectedSubnetInfo()
+	subnetInfo.VnetName = caseMismatchVnetName
+	// subnetInfo.SubnetID keeps expectedAmlFilesystemSubnetID's normal casing,
+	// while the fake ARM server (keyed off caseMismatchVnetName) returns the
+	// same subnet ID as caseMismatchAmlFilesystemSubnetID (upper-cased).
+	hasSufficientCapacity, err := dynamicProvisioner.CheckSubnetCapacity(context.Background(), subnetInfo, expectedSku, expectedClusterSize)
+	require.NoError(t, err)
+	assert.True(t, hasSufficientCapacity)
 }
 
 func TestDynamicProvisioner_CheckSubnetCapacity_Err_NilMgmtClient(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
 Azure resource group names are case-insensitive, but different ARM endpoints may echo back different casing for the same resource ID, so compare case-insensitively to avoid false "subnet not found" errors

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: Fixes #290   
-->
Fixes #

**Requirements**:
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version
