### PR TITLE
security: mount host config files (azure.json, os-release) read-only in CSI pods

### DIFF
--- a/charts/latest/azurelustre-csi-driver/templates/controller-deployment.yaml
+++ b/charts/latest/azurelustre-csi-driver/templates/controller-deployment.yaml
@@ -171,6 +171,7 @@ spec:
               name: socket-dir
             - mountPath: {{ .Values.paths.kubernetes }}/
               name: azure-cred
+              readOnly: true
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
       volumes:

--- a/charts/latest/azurelustre-csi-driver/templates/node-daemonset-azurelinux3.yaml
+++ b/charts/latest/azurelustre-csi-driver/templates/node-daemonset-azurelinux3.yaml
@@ -102,6 +102,7 @@ spec:
               name: host-dev
             - mountPath: /etc/host-os-release
               name: host-os-release
+              readOnly: true
             - mountPath: /app/custom-entrypoint
               name: custom-entrypoint
               readOnly: true
@@ -219,10 +220,12 @@ spec:
               mountPropagation: Bidirectional
             - mountPath: {{ .Values.paths.kubernetes }}/
               name: azure-cred
+              readOnly: true
             - mountPath: {{ .Values.paths.dev }}
               name: host-dev
             - mountPath: /etc/host-os-release
               name: host-os-release
+              readOnly: true
             - mountPath: /app/custom-entrypoint
               name: custom-entrypoint
               readOnly: true

--- a/charts/latest/azurelustre-csi-driver/templates/node-daemonset-jammy.yaml
+++ b/charts/latest/azurelustre-csi-driver/templates/node-daemonset-jammy.yaml
@@ -102,6 +102,7 @@ spec:
               name: host-dev
             - mountPath: /etc/host-os-release
               name: host-os-release
+              readOnly: true
             - mountPath: /app/custom-entrypoint
               name: custom-entrypoint
               readOnly: true
@@ -219,10 +220,12 @@ spec:
               mountPropagation: Bidirectional
             - mountPath: {{ .Values.paths.kubernetes }}/
               name: azure-cred
+              readOnly: true
             - mountPath: {{ .Values.paths.dev }}
               name: host-dev
             - mountPath: /etc/host-os-release
               name: host-os-release
+              readOnly: true
             - mountPath: /app/custom-entrypoint
               name: custom-entrypoint
               readOnly: true

--- a/charts/latest/azurelustre-csi-driver/templates/node-daemonset-noble.yaml
+++ b/charts/latest/azurelustre-csi-driver/templates/node-daemonset-noble.yaml
@@ -102,6 +102,7 @@ spec:
               name: host-dev
             - mountPath: /etc/host-os-release
               name: host-os-release
+              readOnly: true
             - mountPath: /app/custom-entrypoint
               name: custom-entrypoint
               readOnly: true
@@ -219,10 +220,12 @@ spec:
               mountPropagation: Bidirectional
             - mountPath: {{ .Values.paths.kubernetes }}/
               name: azure-cred
+              readOnly: true
             - mountPath: {{ .Values.paths.dev }}
               name: host-dev
             - mountPath: /etc/host-os-release
               name: host-os-release
+              readOnly: true
             - mountPath: /app/custom-entrypoint
               name: custom-entrypoint
               readOnly: true


### PR DESCRIPTION
# Pull Request

## What type of PR is this?

/kind cleanup

## What this PR does / why we need it

Two host config files are mounted into the CSI pods via `hostPath` but were mounted **read-write**, even though the driver only ever **reads** them. This sets `readOnly: true` on both.

**`/etc/kubernetes` (azure.json — the AKS cloud-provider config)** — controller Deployment + all node DaemonSets:

- Sole access is `os.ReadFile` in the cloud-provider-azure `configloader` (`loader_file.go`).
- `InitializeCloudFromConfig` operates on the parsed **in-memory** struct, not the file path.
- The driver's only filesystem writes (CSI socket removal, mount-target create/remove) target `/csi` and kubelet plugin directories — never `/etc/kubernetes`.

**`/etc/host-os-release` (the node's `/etc/os-release`)** — mounted into both the `lustre-loader` init container and the `azurelustre` container of every node DaemonSet:

- The entrypoint only sources/greps it to detect the host OS (`entrypoint.sh`); it is never written.

Setting `readOnly: true` is safe **defense-in-depth**: a compromised CSI container can no longer write back to the node's `/etc/kubernetes` or `/etc/os-release` via these mounts. No functional change.

The privileged mount container's `/dev` (`host-dev`) mount is intentionally left **writable** — the node plugin performs kernel Lustre mounts and device access through it. All other remaining writable mounts (`socket-dir`, `mountpoint-dir`, `registration-dir`) are sockets / mount-propagation paths the driver and sidecars write to by design.

## Testing

Validated end-to-end on a live **AKS + Azure Managed Lustre** cluster (canadacentral, Ubuntu 24.04 node, driver `v0.5.0-noble`), installing this branch's chart via Helm (`IsWorkloadIdentityEnabled=Disabled`):

- **Static (all pass):** `helm lint`; `helm template` renders; diff is only the added `readOnly: true` lines. Rendered chart confirms all 4 `azure-cred` + all 6 `host-os-release` mounts carry `readOnly: true`; `host-dev` remains writable.
- **Pods:** controller `3/3` and node `4/4` reach Ready. The `lustre-loader` init container installs the Lustre client while reading `/etc/host-os-release` **read-only** — completes successfully.
- **Controller:** reads `/etc/kubernetes/azure.json` **read-only**, initializes the ARM client factory, and authenticates via managed identity using the client ID from `azure.json` (non-WIF path) — confirmed in logs.
- **Negative check:** `touch /etc/kubernetes/...` and writing to `/etc/host-os-release` both fail with `Read-only file system`, while `azure.json` remains readable — confirming the flag is enforced without breaking config reads.
- **Data plane:** a pod statically mounts the AMLFS (`<mgs>@tcp:/lustrefs`, 4 TiB); file write/read succeeds and `dd` sustains 50 MiB at ~313 MB/s.
- **Logs:** no `read-only file system` / permission errors across any pod.

Resources were torn down after the run.

## Which issue(s) this PR fixes

Fixes #

## Requirements

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

## Special notes for your reviewer

Chart-only change targeting `development` (where the Helm chart lives). Heads-up: the node DaemonSet templates are also touched by the in-flight namespace-migration branch, so a trivial rebase/coordination may be needed depending on merge order.

## Release note

```text
The CSI controller and node pods now mount the host /etc/kubernetes (azure.json) cloud-provider config and /etc/host-os-release as read-only.
```