### PR TITLE
security: sync deploy manifests with chart readOnly mounts (follow-up to #320)

### DIFF
--- a/deploy/csi-azurelustre-controller.yaml
+++ b/deploy/csi-azurelustre-controller.yaml
@@ -178,6 +178,7 @@ spec:
               name: socket-dir
             - mountPath: /etc/kubernetes/
               name: azure-cred
+              readOnly: true
           resources:
             limits:
               cpu: 1

--- a/deploy/csi-azurelustre-node-azurelinux3.yaml
+++ b/deploy/csi-azurelustre-node-azurelinux3.yaml
@@ -126,6 +126,7 @@ spec:
               name: host-dev
             - mountPath: /etc/host-os-release
               name: host-os-release
+              readOnly: true
             - mountPath: /app/custom-entrypoint
               name: custom-entrypoint
               readOnly: true
@@ -274,10 +275,12 @@ spec:
               mountPropagation: "Bidirectional"
             - mountPath: /etc/kubernetes/
               name: azure-cred
+              readOnly: true
             - mountPath: /dev
               name: host-dev
             - mountPath: /etc/host-os-release
               name: host-os-release
+              readOnly: true
             - mountPath: /app/custom-entrypoint
               name: custom-entrypoint
               readOnly: true

--- a/deploy/csi-azurelustre-node-jammy.yaml
+++ b/deploy/csi-azurelustre-node-jammy.yaml
@@ -127,6 +127,7 @@ spec:
               name: host-dev
             - mountPath: /etc/host-os-release
               name: host-os-release
+              readOnly: true
             - mountPath: /app/custom-entrypoint
               name: custom-entrypoint
               readOnly: true
@@ -270,10 +271,12 @@ spec:
               mountPropagation: Bidirectional
             - mountPath: /etc/kubernetes/
               name: azure-cred
+              readOnly: true
             - mountPath: /dev
               name: host-dev
             - mountPath: /etc/host-os-release
               name: host-os-release
+              readOnly: true
             - mountPath: /app/custom-entrypoint
               name: custom-entrypoint
               readOnly: true

--- a/deploy/csi-azurelustre-node-noble.yaml
+++ b/deploy/csi-azurelustre-node-noble.yaml
@@ -125,6 +125,7 @@ spec:
               name: host-dev
             - mountPath: /etc/host-os-release
               name: host-os-release
+              readOnly: true
             - mountPath: /app/custom-entrypoint
               name: custom-entrypoint
               readOnly: true
@@ -268,10 +269,12 @@ spec:
               mountPropagation: Bidirectional
             - mountPath: /etc/kubernetes/
               name: azure-cred
+              readOnly: true
             - mountPath: /dev
               name: host-dev
             - mountPath: /etc/host-os-release
               name: host-os-release
+              readOnly: true
             - mountPath: /app/custom-entrypoint
               name: custom-entrypoint
               readOnly: true


### PR DESCRIPTION
Follow-up to #320.

**What this PR does / why we need it**

PR #320 marked the host config mounts (`azure-cred` → `/etc/kubernetes`, `host-os-release` → `/etc/host-os-release`) read-only in the **Helm chart** templates, but the raw `deploy/*.yaml` manifests were not updated in the same change. This left the chart and the deploy manifests out of sync (`hack/verify-helm-chart-files.sh` now diverges on `development`).

This PR applies the identical `readOnly: true` hardening to the deploy manifests so the two stay in lockstep:

- `deploy/csi-azurelustre-controller.yaml` — `azure-cred` mount
- `deploy/csi-azurelustre-node-jammy.yaml` — `azure-cred` + `host-os-release` (init + main containers)
- `deploy/csi-azurelustre-node-noble.yaml` — same
- `deploy/csi-azurelustre-node-azurelinux3.yaml` — same

**Special notes for your reviewer**

Verified locally with `make verify` (exit 0) — including `hack/verify-helm-chart-files.sh`, which now reports **no significant differences** between the chart render and the deploy manifests.

These mounts are read-only in all code paths: `azure.json` is only read (once, via `os.ReadFile` in configloader) and `/etc/host-os-release` is only sourced/grep'd by `entrypoint.sh`. The chart-side change (#320) was validated on a live AKS + AMLFS cluster (mount + I/O smoke test); this PR is a pure manifest-sync of that same change.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```