### PR TITLE
feat: support optional digest pinning for CSI sidecar images

### DIFF
--- a/charts/latest/azurelustre-csi-driver/templates/_helpers.tpl
+++ b/charts/latest/azurelustre-csi-driver/templates/_helpers.tpl
@@ -66,3 +66,25 @@ imagePullSecrets:
   {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Render a container image reference.
+Args (dict): repository (required), tag (required), suffix (optional flavor
+suffix, e.g. "-noble"), digest (optional "sha256:...").
+Renders "<repository>:<tag><suffix>". When digest is set, it is trimmed and
+validated as "sha256:<64 hex>" then appended as "@<digest>" so the image is
+pulled by immutable digest while the tag stays human-readable. A malformed
+digest fails the render (fast, local) instead of surfacing as a runtime
+ImagePullBackOff. Empty digest reproduces the historical tag-only reference.
+*/}}
+{{- define "azurelustre.imageRef" -}}
+{{- $ref := printf "%s:%s%s" .repository .tag (default "" .suffix) -}}
+{{- with .digest -}}
+{{- $d := trim . -}}
+{{- if not (regexMatch "^sha256:[0-9a-f]{64}$" $d) -}}
+{{- fail (printf "azurelustre.imageRef: invalid image digest %q (expected sha256:<64 hex chars>)" $d) -}}
+{{- end -}}
+{{- $ref = printf "%s@%s" $ref $d -}}
+{{- end -}}
+{{- $ref -}}
+{{- end -}}

--- a/charts/latest/azurelustre-csi-driver/templates/controller-deployment.yaml
+++ b/charts/latest/azurelustre-csi-driver/templates/controller-deployment.yaml
@@ -95,7 +95,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-provisioner
-          image: {{ .Values.sidecars.provisioner.repository }}:{{ .Values.sidecars.provisioner.tag }}
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.sidecars.provisioner.repository "tag" .Values.sidecars.provisioner.tag "digest" .Values.sidecars.provisioner.digest) }}
           args:
             - -v=2
             - --leader-election
@@ -117,7 +117,7 @@ spec:
               drop:
                 - ALL
         - name: liveness-probe
-          image: {{ .Values.sidecars.livenessProbe.repository }}:{{ .Values.sidecars.livenessProbe.tag }}
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.sidecars.livenessProbe.repository "tag" .Values.sidecars.livenessProbe.tag "digest" .Values.sidecars.livenessProbe.digest) }}
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=120s
@@ -133,7 +133,7 @@ spec:
               drop:
                 - ALL
         - name: azurelustre
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}-noble
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.image.repository "tag" .Values.image.tag "suffix" "-noble") }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
 {{- range $arg := .Values.controller.extraArgs }}

--- a/charts/latest/azurelustre-csi-driver/templates/node-daemonset-azurelinux3.yaml
+++ b/charts/latest/azurelustre-csi-driver/templates/node-daemonset-azurelinux3.yaml
@@ -59,7 +59,7 @@ spec:
         {{- toYaml .Values.node.tolerations | nindent 8 }}
       initContainers:
         - name: lustre-loader
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}-azurelinux3
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.image.repository "tag" .Values.image.tag "suffix" "-azurelinux3") }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           restartPolicy: Always
           securityContext:
@@ -110,7 +110,7 @@ spec:
             {{- toYaml .Values.node.azurelinux3.resources | nindent 12 }}
       containers:
         - name: liveness-probe
-          image: {{ .Values.sidecars.livenessProbe.repository }}:{{ .Values.sidecars.livenessProbe.tag }}
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.sidecars.livenessProbe.repository "tag" .Values.sidecars.livenessProbe.tag "digest" .Values.sidecars.livenessProbe.digest) }}
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=120s
@@ -127,7 +127,7 @@ spec:
               drop:
                 - ALL
         - name: node-driver-registrar
-          image: {{ .Values.sidecars.nodeDriverRegistrar.repository }}:{{ .Values.sidecars.nodeDriverRegistrar.tag }}
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.sidecars.nodeDriverRegistrar.repository "tag" .Values.sidecars.nodeDriverRegistrar.tag "digest" .Values.sidecars.nodeDriverRegistrar.digest) }}
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -158,7 +158,7 @@ spec:
               drop:
                 - ALL
         - name: azurelustre
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}-azurelinux3
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.image.repository "tag" .Values.image.tag "suffix" "-azurelinux3") }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
 {{- range $arg := .Values.node.extraArgs }}

--- a/charts/latest/azurelustre-csi-driver/templates/node-daemonset-jammy.yaml
+++ b/charts/latest/azurelustre-csi-driver/templates/node-daemonset-jammy.yaml
@@ -59,7 +59,7 @@ spec:
         {{- toYaml .Values.node.tolerations | nindent 8 }}
       initContainers:
         - name: lustre-loader
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}-jammy
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.image.repository "tag" .Values.image.tag "suffix" "-jammy") }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           restartPolicy: Always
           securityContext:
@@ -110,7 +110,7 @@ spec:
             {{- toYaml .Values.node.jammy.resources | nindent 12 }}
       containers:
         - name: liveness-probe
-          image: {{ .Values.sidecars.livenessProbe.repository }}:{{ .Values.sidecars.livenessProbe.tag }}
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.sidecars.livenessProbe.repository "tag" .Values.sidecars.livenessProbe.tag "digest" .Values.sidecars.livenessProbe.digest) }}
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=120s
@@ -127,7 +127,7 @@ spec:
               drop:
                 - ALL
         - name: node-driver-registrar
-          image: {{ .Values.sidecars.nodeDriverRegistrar.repository }}:{{ .Values.sidecars.nodeDriverRegistrar.tag }}
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.sidecars.nodeDriverRegistrar.repository "tag" .Values.sidecars.nodeDriverRegistrar.tag "digest" .Values.sidecars.nodeDriverRegistrar.digest) }}
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -158,7 +158,7 @@ spec:
               drop:
                 - ALL
         - name: azurelustre
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}-jammy
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.image.repository "tag" .Values.image.tag "suffix" "-jammy") }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
 {{- range $arg := .Values.node.extraArgs }}

--- a/charts/latest/azurelustre-csi-driver/templates/node-daemonset-noble.yaml
+++ b/charts/latest/azurelustre-csi-driver/templates/node-daemonset-noble.yaml
@@ -59,7 +59,7 @@ spec:
         {{- toYaml .Values.node.tolerations | nindent 8 }}
       initContainers:
         - name: lustre-loader
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}-noble
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.image.repository "tag" .Values.image.tag "suffix" "-noble") }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           restartPolicy: Always
           securityContext:
@@ -110,7 +110,7 @@ spec:
             {{- toYaml .Values.node.noble.resources | nindent 12 }}
       containers:
         - name: liveness-probe
-          image: {{ .Values.sidecars.livenessProbe.repository }}:{{ .Values.sidecars.livenessProbe.tag }}
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.sidecars.livenessProbe.repository "tag" .Values.sidecars.livenessProbe.tag "digest" .Values.sidecars.livenessProbe.digest) }}
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=120s
@@ -127,7 +127,7 @@ spec:
               drop:
                 - ALL
         - name: node-driver-registrar
-          image: {{ .Values.sidecars.nodeDriverRegistrar.repository }}:{{ .Values.sidecars.nodeDriverRegistrar.tag }}
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.sidecars.nodeDriverRegistrar.repository "tag" .Values.sidecars.nodeDriverRegistrar.tag "digest" .Values.sidecars.nodeDriverRegistrar.digest) }}
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -158,7 +158,7 @@ spec:
               drop:
                 - ALL
         - name: azurelustre
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}-noble
+          image: {{ include "azurelustre.imageRef" (dict "repository" .Values.image.repository "tag" .Values.image.tag "suffix" "-noble") }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
 {{- range $arg := .Values.node.extraArgs }}

--- a/charts/latest/azurelustre-csi-driver/values.yaml
+++ b/charts/latest/azurelustre-csi-driver/values.yaml
@@ -3,11 +3,19 @@ image:
   repository: mcr.microsoft.com/oss/v2/kubernetes-csi/azurelustre-csi
   tag: latest
   pullPolicy: Always
+  # The driver image is intentionally referenced by tag, not by digest. It is
+  # published by the first-party DALEC pipeline, which republishes CVE and
+  # dependency fixes under the same release tag (e.g. "v0.5.0-noble" -> "-1",
+  # "-2", ...). Pinning a digest would freeze the driver on a fixed base image
+  # and suppress those automatic CVE refreshes until a full patch release, so
+  # supply-chain integrity is instead provided by DALEC signing/provenance/SBOM.
 
 sidecars:
   provisioner:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner
     tag: v5.2.0
+    # Optional immutable digest ("sha256:..."); empty = pull by tag.
+    digest: ""
     resources:
       limits:
         cpu: 100m
@@ -18,6 +26,8 @@ sidecars:
   livenessProbe:
     repository: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe
     tag: v2.15.0
+    # Optional immutable digest ("sha256:..."); empty = pull by tag.
+    digest: ""
     resources:
       limits:
         cpu: 100m
@@ -34,6 +44,8 @@ sidecars:
   nodeDriverRegistrar:
     repository: mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar
     tag: v2.13.0
+    # Optional immutable digest ("sha256:..."); empty = pull by tag.
+    digest: ""
     resources:
       limits:
         cpu: 100m


### PR DESCRIPTION
**What this PR does / why we need it**

Adds an optional per-sidecar image digest to the chart so deployed workloads can pull the CSI sidecar images (`csi-provisioner`, `livenessprobe`, `csi-node-driver-registrar`) by immutable `sha256` digest instead of by mutable tag, while keeping the human-readable tag in the reference. This is supply-chain hardening for first-party (AKS extension) publishing; it is fully opt-in and default-off.

A new `azurelustre.imageRef` helper renders `<repo>:<tag><suffix>` and, when a digest is supplied, trims it, validates it as `sha256:<64 hex>`, and appends `@<digest>`. A malformed digest fails the render locally instead of surfacing later as a runtime `ImagePullBackOff`. `values.yaml` gains an empty `digest` field on each sidecar.

**Why the driver image is intentionally NOT digest-pinnable**

The driver image is published by the first-party DALEC pipeline, which republishes CVE and dependency fixes under the same release tag (e.g. `v0.5.0-noble` -> `-1`, `-2`, ...; the prior release accumulated 30+ such rebuilds). Pinning the driver to a digest would freeze it on a fixed base image and suppress those automatic CVE refreshes until a full patch release + customer upgrade — undermining DALEC's model. Driver supply-chain integrity is instead provided by DALEC signing/provenance/SBOM. Sidecar version tags are immutable (no such republish), so pinning them is pure upside.

**Special notes for your reviewer**

Empty digests reproduce the exact previous tag-only references, so rendered output is byte-for-byte unchanged by default and `deploy/` manifests stay in sync (verified via `hack/verify-helm-chart-files.sh` and `make verify`).

**Does this PR introduce a user-facing change?**

```release-note
The Helm chart now supports optional immutable digest pinning for the CSI sidecar images via `sidecars.<name>.digest`. Default behavior is unchanged (images are still referenced by tag when no digest is set).
```